### PR TITLE
[Feat] 스웨거 오류 코드 관련 응답 예시 추가 및 오류 로직 점검

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/auth/exception/AuthErrorCode.java
@@ -12,33 +12,38 @@ public enum AuthErrorCode implements ErrorCode {
     /**
      * JWT 토큰 관련 에러코드들
      */
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH001", "유효하지 않은 토큰입니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH002", "만료된 토큰입니다."),
-    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH003", "지원되지 않는 토큰입니다."),
-    TOKEN_VALIDATION_ERROR(HttpStatus.UNAUTHORIZED, "AUTH004", "토큰 검증 중 오류가 발생했습니다."),
-    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH005", "잘못된 형식의 토큰입니다."),
-    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH006", "토큰이 비어있습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", "만료된 토큰입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "UNSUPPORTED_TOKEN", "지원되지 않는 토큰입니다."),
+    TOKEN_VALIDATION_ERROR(HttpStatus.UNAUTHORIZED, "TOKEN_VALIDATION_ERROR", "토큰 검증 중 오류가 발생했습니다."),
+    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "MALFORMED_TOKEN", "잘못된 형식의 토큰입니다."),
+    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "EMPTY_TOKEN", "토큰이 비어있습니다."),
+    INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "INVALID_SIGNATURE", "잘못된 토큰 서명입니다."),
 
     /**
-     * 인증 관련 에러코드들
+     * 인증/인가 관련 에러코드들
      */
-    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH101", "인증에 실패했습니다."),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH102", "접근이 거부되었습니다."),
-    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH103", "사용자를 찾을 수 없습니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTHENTICATION_FAILED", "인증에 실패했습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "ACCESS_DENIED", "접근이 거부되었습니다."),
+    /**
+     * 인증 정보(e.g., JWT, Firebase UID)는 유효하나,
+     * 해당 정보에 매핑되는 사용자가 우리 DB에 존재하지 않을 때 (e.g., 탈퇴, DB 누락)
+     */
+    AUTHENTICATION_USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTHENTICATION_USER_NOT_FOUND", "인증된 사용자를 찾을 수 없습니다."),
 
     /**
      * Refresh Token 관련 에러코드들
      */
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH201", "유효하지 않은 리프레시 토큰입니다."),
-    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH202", "만료된 리프레시 토큰입니다."),
-    USED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH203", "이미 사용된 리프레시 토큰입니다."),
-    REVOKED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH204", "무효화된 리프레시 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", "유효하지 않은 리프레시 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_REFRESH_TOKEN", "만료된 리프레시 토큰입니다."),
+    USED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "USED_REFRESH_TOKEN", "이미 사용된 리프레시 토큰입니다."),
+    REVOKED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "REVOKED_REFRESH_TOKEN", "무효화된 리프레시 토큰입니다."),
 
     /**
-     * 기타 에러코드들
+     * 기타 에러코드
      */
-    INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "AUTH301", "잘못된 토큰 서명입니다."),
-    UNKNOWN_AUTH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH999", "알 수 없는 인증 오류가 발생했습니다.");
+    UNKNOWN_AUTH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "UNKNOWN_AUTH_ERROR", "알 수 없는 인증 오류가 발생했습니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ridingmate/api_server/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/ridingmate/api_server/domain/auth/exception/AuthException.java
@@ -1,0 +1,9 @@
+package com.ridingmate.api_server.domain.auth.exception;
+
+import com.ridingmate.api_server.global.exception.BusinessException;
+
+public class AuthException extends BusinessException {
+    public AuthException (AuthErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
@@ -1,12 +1,18 @@
 package com.ridingmate.api_server.domain.route.controller;
 
+import com.ridingmate.api_server.domain.auth.exception.AuthErrorCode;
 import com.ridingmate.api_server.domain.route.dto.request.CreateRouteRequest;
 import com.ridingmate.api_server.domain.route.dto.request.RouteListRequest;
 import com.ridingmate.api_server.domain.route.dto.request.RouteSegmentRequest;
 import com.ridingmate.api_server.domain.route.dto.response.*;
+import com.ridingmate.api_server.domain.route.exception.code.RouteCommonErrorCode;
 import com.ridingmate.api_server.domain.route.exception.RouteSuccessCode;
+import com.ridingmate.api_server.domain.route.exception.code.RouteCreationErrorCode;
 import com.ridingmate.api_server.domain.route.facade.RouteFacade;
+import com.ridingmate.api_server.global.exception.ApiErrorCodeExample;
 import com.ridingmate.api_server.global.exception.CommonResponse;
+import com.ridingmate.api_server.infra.kakao.KakaoErrorCode;
+import com.ridingmate.api_server.infra.ors.OrsErrorCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +27,8 @@ public class RouteController implements RouteApi{
 
     @Override
     @PostMapping("/segment")
+    @ApiErrorCodeExample(RouteCommonErrorCode.class)
+    @ApiErrorCodeExample(OrsErrorCode.class)
     public ResponseEntity<CommonResponse<RouteSegmentResponse>>previewRoute(@RequestBody RouteSegmentRequest request) {
         RouteSegmentResponse response = routeFacade.generateSegment(request);
         return ResponseEntity
@@ -30,6 +38,8 @@ public class RouteController implements RouteApi{
 
     @Override
     @PostMapping
+    @ApiErrorCodeExample(RouteCreationErrorCode.class)
+    @ApiErrorCodeExample(AuthErrorCode.class)
     public ResponseEntity<CommonResponse<CreateRouteResponse>> createRoute(@Valid @RequestBody CreateRouteRequest request) {
         CreateRouteResponse response = routeFacade.createRoute(request);
         return ResponseEntity.
@@ -39,6 +49,7 @@ public class RouteController implements RouteApi{
 
     @Override
     @GetMapping("/{routeId}/share")
+    @ApiErrorCodeExample(RouteCommonErrorCode.class)
     public ResponseEntity<CommonResponse<ShareRouteResponse>> shareRoute(@PathVariable Long routeId) {
         ShareRouteResponse  response = routeFacade.shareRoute(routeId);
         return ResponseEntity
@@ -62,6 +73,7 @@ public class RouteController implements RouteApi{
 
     @Override
     @GetMapping("/search")
+    @ApiErrorCodeExample(KakaoErrorCode.class)
     public ResponseEntity<CommonResponse<MapSearchResponse>> getMapSearch(
             @RequestParam String query,
             @RequestParam Double lon,

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/request/RecommendationListRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/request/RecommendationListRequest.java
@@ -13,37 +13,34 @@ import java.util.List;
 @ParameterObject
 public record RecommendationListRequest(
     @Parameter(
-            description = "페이지 번호 (0부터 시작)",
+            description = "페이지 번호 (기본 값: 0)",
             example = "0",
-            schema = @Schema(defaultValue = "0"),
-            required = true
+            schema = @Schema(type = "integer", defaultValue = "0")
     )
     int page,
     
     @Parameter(
-            description = "페이지 크기",
+            description = "페이지 크기 (기본 값: 10)",
             example = "10",
-            schema = @Schema(defaultValue = "10"),
-            required = true
+            schema = @Schema(type = "integer", defaultValue = "10")
     )
     int size,
     
     @Parameter(
-            description = "정렬 타입",
+            description = "정렬 타입 (기본 값: 가까운 순)",
             example = "NEAREST",
-            schema = @Schema(defaultValue = "NEAREST"),
-            required = true
+            schema = @Schema(defaultValue = "NEAREST")
     )
     RecommendationSortType sortType,
     
     @Parameter(
-            description = "추천 타입 필터 (여러 값 지정 가능, 미지정시 전체 선택)",
+            description = "추천 타입 필터 (기본 값: 전체 선택 / 다중 선택 가능)",
             example = "CROSS_COUNTRY,COMPETITION,FAMOUS"
     )
     List<RecommendationType> recommendationTypes,
     
     @Parameter(
-            description = "지역 필터 (여러 값 지정 가능, 미지정시 전체 선택)",
+            description = "지역 필터 (기본 값: 전체 선택 / 다중 선택 가능)",
             example = "SEOUL,GANGWON"
     )
     List<Region> regions,
@@ -77,7 +74,7 @@ public record RecommendationListRequest(
     Double maxElevationGain,
     
     @Parameter(
-            description = "난이도 필터 (여러 값 지정 가능, 미지정시 전체 선택)",
+            description = "난이도 필터 (기본 값: 전체 선택 / 다중 선택 가능)",
             example = "EASY,MEDIUM"
     )
     List<Difficulty> difficulties,

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/request/RouteListRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/request/RouteListRequest.java
@@ -11,38 +11,35 @@ import java.util.List;
 @ParameterObject
 public record RouteListRequest(
     @Parameter(
-            description = "페이지 번호 (0부터 시작)",
-            example = "0",
-            schema = @Schema(defaultValue = "0"),
-            required = true
+        description = "페이지 번호 (기본 값: 0)",
+        example = "0",
+        schema = @Schema(type = "integer", defaultValue = "0")
     )
     int page,
     
     @Parameter(
-            description = "페이지 크기",
-            example = "3",
-            schema = @Schema(defaultValue = "3"),
-            required = true
+        description = "페이지 크기 (기본 값: 10)",
+        example = "10",
+        schema = @Schema(type = "integer", defaultValue = "10")
     )
     int size,
     
     @Parameter(
-            description = "정렬 타입",
+            description = "정렬 타입 (기본 값: 최근 생성 순)",
             example = "CREATED_AT_DESC",
-            schema = @Schema(defaultValue = "CREATED_AT_DESC"),
-            required = true
+            schema = @Schema(defaultValue = "CREATED_AT_DESC")
     )
     RouteSortType sortType,
     
     @Parameter(
-            description = "관계 타입 필터 (여러 값 지정 가능, 미지정시 전체 선택)",
+            description = "관계 타입 필터 (기본 값: 전체 선택 / 다중 선택 가능)",
             example = "OWNER,SHARED"
     )
     List<RouteRelationType> relationTypes,
     
     @Parameter(
             description = "최소 거리 (km)",
-            example = "10.0",
+            example = "0.0",
             required = true
     )
     Double minDistanceKm,
@@ -56,7 +53,7 @@ public record RouteListRequest(
     
     @Parameter(
             description = "최소 고도 상승 (미터)",
-            example = "100.0",
+            example = "0.0",
             required = true
     )
     Double minElevationGain,

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteException.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteException.java
@@ -1,10 +1,21 @@
 package com.ridingmate.api_server.domain.route.exception;
 
+import com.ridingmate.api_server.domain.route.exception.code.RouteCommonErrorCode;
+import com.ridingmate.api_server.domain.route.exception.code.RouteCreationErrorCode;
+import com.ridingmate.api_server.domain.route.exception.code.RouteShareErrorCode;
 import com.ridingmate.api_server.global.exception.BusinessException;
 
 public class RouteException extends BusinessException {
 
-    public RouteException(RouteErrorCode errorCode) {
+    public RouteException(RouteCommonErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public RouteException(RouteShareErrorCode errorCode){
+        super(errorCode);
+    }
+
+    public RouteException(RouteCreationErrorCode errorCode){
         super(errorCode);
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/code/RouteCommonErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/code/RouteCommonErrorCode.java
@@ -1,4 +1,4 @@
-package com.ridingmate.api_server.domain.route.exception;
+package com.ridingmate.api_server.domain.route.exception.code;
 
 import com.ridingmate.api_server.global.exception.ErrorCode;
 import lombok.Getter;
@@ -7,9 +7,9 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum RouteErrorCode implements ErrorCode {
+public enum RouteCommonErrorCode implements ErrorCode {
     ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "ROUTE_NOT_FOUND", "경로를 찾을 수 없습니다."),
-    SHARE_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "SHARE_ID_NOT_FOUND", "경로의 공유 식별자를 찾을 수 없습니다.")
+    ROUTE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ROUTE_ACCESS_DENIED", "해당 경로에 접근 권한이 없습니다"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/code/RouteCreationErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/code/RouteCreationErrorCode.java
@@ -1,0 +1,18 @@
+package com.ridingmate.api_server.domain.route.exception.code;
+
+import com.ridingmate.api_server.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RouteCreationErrorCode implements ErrorCode {
+    ROUTE_POLYLINE_INVALID(HttpStatus.BAD_REQUEST, "ROUTE_POLYLINE_INVALID", "Polyline 형식이 올바르지 않습니다."),
+    ROUTE_NOT_ENOUGH_POINTS(HttpStatus.BAD_REQUEST, " ROUTE_NOT_ENOUGH_POINTS", "경로를 생성하려면 최소 2개 이상의 지점이 필요합니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/code/RouteShareErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/code/RouteShareErrorCode.java
@@ -1,0 +1,16 @@
+package com.ridingmate.api_server.domain.route.exception.code;
+
+import com.ridingmate.api_server.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RouteShareErrorCode implements ErrorCode {
+    SHARE_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "SHARE_ID_NOT_FOUND", "경로의 공유 식별자를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
@@ -21,8 +21,6 @@ import org.locationtech.jts.geom.LineString;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.List;
 
 @Component
@@ -52,7 +50,10 @@ public class RouteFacade {
     }
 
     public ShareRouteResponse shareRoute(Long routeId) {
-        String shareLink = routeService.createShareLink(routeId);
+        //TODO 추후 변경 필요
+        Long userId = 1L;
+
+        String shareLink = routeService.createShareLink(routeId, userId);
         return new ShareRouteResponse(shareLink);
     }
 

--- a/src/main/java/com/ridingmate/api_server/global/config/ErrorCodeCustomizer.java
+++ b/src/main/java/com/ridingmate/api_server/global/config/ErrorCodeCustomizer.java
@@ -52,7 +52,7 @@ public class ErrorCodeCustomizer implements OperationCustomizer {
                         try {
                             return ExampleHolder.builder()
                                 .holder(
-                                    getSwaggerExxample(
+                                    getSwaggerExample(
                                         errorCode
                                     )
                                 )
@@ -67,7 +67,7 @@ public class ErrorCodeCustomizer implements OperationCustomizer {
         addExamplesToResponses(responses, statusWithExampleHolders);
     }
 
-    private Example getSwaggerExxample(ErrorCode errorCode) {
+    private Example getSwaggerExample(ErrorCode errorCode) {
         ErrorResponse errorResponse = ErrorResponse.of(errorCode);
         Example example = new Example();
         example.setValue(errorResponse);

--- a/src/main/java/com/ridingmate/api_server/global/config/ErrorCodeCustomizer.java
+++ b/src/main/java/com/ridingmate/api_server/global/config/ErrorCodeCustomizer.java
@@ -1,0 +1,105 @@
+package com.ridingmate.api_server.global.config;
+
+import com.ridingmate.api_server.global.exception.ApiErrorCodeExample;
+import com.ridingmate.api_server.global.exception.ErrorCode;
+import com.ridingmate.api_server.global.exception.ErrorResponse;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import lombok.Builder;
+import lombok.Getter;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.groupingBy;
+
+@Component
+public class ErrorCodeCustomizer implements OperationCustomizer {
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        Set<ApiErrorCodeExample> errorCodeExamples = AnnotatedElementUtils.findMergedRepeatableAnnotations(
+            handlerMethod.getMethod(), ApiErrorCodeExample.class);
+
+        if (!errorCodeExamples.isEmpty()) {
+            errorCodeExamples.forEach(errorCodeExample -> {
+                generateErrorCodeResponseExample(operation, errorCodeExample.value());
+            });
+        }
+
+        return operation;
+    }
+
+    private void generateErrorCodeResponseExample(Operation operation, Class<? extends ErrorCode> type){
+        ApiResponses responses = operation.getResponses();
+
+        ErrorCode[] errorCodes = type.getEnumConstants();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders =
+            Arrays.stream(errorCodes)
+                .map(
+                    errorCode -> {
+                        try {
+                            return ExampleHolder.builder()
+                                .holder(
+                                    getSwaggerExxample(
+                                        errorCode
+                                    )
+                                )
+                                .code(errorCode.getStatus().value())
+                                .name(errorCode.getCode())
+                                .build();
+                        } catch (NoSuchFieldError e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                .collect(groupingBy(ExampleHolder::getCode));
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private Example getSwaggerExxample(ErrorCode errorCode) {
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        Example example = new Example();
+        example.setValue(errorResponse);
+        return example;
+    }
+
+    private void addExamplesToResponses(ApiResponses responses, Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+            (status,  v) -> {
+                Content content  = new Content();
+                MediaType mediaType = new MediaType();
+
+                ApiResponse apiResponse = new ApiResponse();
+
+                v.forEach(
+                    exampleHolder -> mediaType.addExamples(
+                        exampleHolder.getName(), exampleHolder.getHolder()));
+
+                content.addMediaType("application/json", mediaType);
+                apiResponse.setContent(content);
+
+                responses.addApiResponse(status.toString(), apiResponse);
+
+            }
+        );
+    }
+
+    @Getter
+    @Builder
+    public static class ExampleHolder {
+        private Example holder;
+        private String name;
+        private int code;
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/global/exception/ApiErrorCodeExample.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/ApiErrorCodeExample.java
@@ -1,0 +1,10 @@
+package com.ridingmate.api_server.global.exception;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(ApiErrorCodeExamples.class)
+public @interface ApiErrorCodeExample {
+    Class<? extends ErrorCode> value();
+}

--- a/src/main/java/com/ridingmate/api_server/global/exception/ApiErrorCodeExamples.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/ApiErrorCodeExamples.java
@@ -1,0 +1,12 @@
+package com.ridingmate.api_server.global.exception;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExamples {
+    ApiErrorCodeExample[] value();
+}

--- a/src/main/java/com/ridingmate/api_server/global/util/GeometryUtil.java
+++ b/src/main/java/com/ridingmate/api_server/global/util/GeometryUtil.java
@@ -1,5 +1,8 @@
 package com.ridingmate.api_server.global.util;
 
+import com.ridingmate.api_server.domain.route.exception.RouteException;
+import com.ridingmate.api_server.domain.route.exception.code.RouteCreationErrorCode;
+import com.ridingmate.api_server.global.exception.BusinessException;
 import org.locationtech.jts.geom.*;
 
 import java.util.List;
@@ -7,14 +10,21 @@ import java.util.stream.Collectors;
 
 public class GeometryUtil {
 
-    private static final GeometryFactory factory = new GeometryFactory(new PrecisionModel(), 4326);
+    private static final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
     /**
      * Encoded polyline을 LineString으로 변환 예시: LINESTRING (126.9706 37.5547, 127.0276 37.4979, ...)
      */
     public static LineString polylineToLineString(String polyline) {
-        List<Coordinate> coordinates = PolylineDecoder.decode(polyline);
-        return factory.createLineString(coordinates.toArray(new Coordinate[0]));
+        try {
+            List<Coordinate> coordinates = PolylineDecoder.decode(polyline);
+            if (coordinates.size() < 2) {
+                throw new RouteException(RouteCreationErrorCode.ROUTE_NOT_ENOUGH_POINTS);
+            }
+            return geometryFactory.createLineString(coordinates.toArray(new Coordinate[0]));
+        } catch (Exception e) {
+            throw new RouteException(RouteCreationErrorCode.ROUTE_POLYLINE_INVALID);
+        }
     }
 
     /**

--- a/src/main/java/com/ridingmate/api_server/infra/geoapify/GeoapifyErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/infra/geoapify/GeoapifyErrorCode.java
@@ -1,0 +1,31 @@
+package com.ridingmate.api_server.infra.geoapify;
+
+import com.ridingmate.api_server.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GeoapifyErrorCode implements ErrorCode {
+
+    /**
+     * 우리 서버의 로직 또는 설정 오류로 인해 Geoapify가 4xx 에러를 반환한 경우.
+     * 사용자에게는 500 Internal Server Error로 응답해야 함.
+     */
+    GEOAPIFY_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "GEOAPIFY_500_1", "Geoapify API 요청 생성 실패"),
+
+    /**
+     * Geoapify 서버가 5xx 에러로 응답한 경우. (Geoapify 서버 내부 오류)
+     */
+    GEOAPIFY_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "GEOAPIFY_502_1", "Geoapify 서버 내부 오류 발생"),
+
+    /**
+     * Geoapify 서버에 연결할 수 없거나 응답 시간 초과 등 네트워크 문제 발생.
+     */
+    GEOAPIFY_CONNECTION_FAILED(HttpStatus.GATEWAY_TIMEOUT, "GEOAPIFY_504_1", "Geoapify 서버 연결 실패");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/ridingmate/api_server/infra/geoapify/GeoapifyException.java
+++ b/src/main/java/com/ridingmate/api_server/infra/geoapify/GeoapifyException.java
@@ -1,0 +1,11 @@
+package com.ridingmate.api_server.infra.geoapify;
+
+import com.ridingmate.api_server.global.exception.BusinessException;
+import com.ridingmate.api_server.infra.ors.OrsErrorCode;
+
+public class GeoapifyException extends BusinessException {
+
+    public GeoapifyException(GeoapifyErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/infra/kakao/KakaoClient.java
+++ b/src/main/java/com/ridingmate/api_server/infra/kakao/KakaoClient.java
@@ -1,17 +1,22 @@
 package com.ridingmate.api_server.infra.kakao;
 
+import com.ridingmate.api_server.global.exception.BusinessException;
 import com.ridingmate.api_server.infra.kakao.dto.request.KakaoSearchRequest;
 import com.ridingmate.api_server.infra.kakao.dto.response.KakaoSearchResponse;
 import com.ridingmate.api_server.infra.kakao.dto.response.KakaoUserInfoResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 
+@Slf4j
 @RequiredArgsConstructor
 public class KakaoClient {
 
     private final WebClient kakaoWebClient;
+    private final WebClient kakaoApiWebClient;
 
     private static final int DEFAULT_PAGE = 1;
     private static final int DEFAULT_SIZE = 15;
@@ -27,8 +32,21 @@ public class KakaoClient {
                         .queryParam("size", DEFAULT_SIZE)
                         .build())
                 .retrieve()
+                .onStatus(
+                    status -> status.is4xxClientError() || status.is5xxServerError(),
+                    response -> response.bodyToMono(String.class)
+                        .flatMap(errorBody -> {
+                            if (response.statusCode().is4xxClientError()) {
+                                return Mono.error(new KakaoException(KakaoErrorCode.KAKAO_REQUEST_FAILED));
+                            }
+                            return Mono.error(new KakaoException(KakaoErrorCode.KAKAO_SERVER_ERROR));
+                        })
+                )
                 .bodyToMono(KakaoSearchResponse.class)
-                .onErrorMap(throwable -> new KakaoException(KakaoErrorCode.KAKAO_SERVER_CALL_FAILED))
+                .onErrorMap(
+                    throwable -> !(throwable instanceof BusinessException),
+                    throwable -> new KakaoException(KakaoErrorCode.KAKAO_CONNECTION_FAILED)
+                )
                 .block();
     }
 
@@ -39,15 +57,25 @@ public class KakaoClient {
      * @return KakaoUserInfoResponse 사용자 정보
      */
     public KakaoUserInfoResponse getUserInfo(String accessToken) {
-        return WebClient.builder()
-                .baseUrl("https://kapi.kakao.com")
-                .defaultHeader("Authorization", "Bearer " + accessToken)
-                .build()
-                .get()
-                .uri("/v2/user/me")
-                .retrieve()
-                .bodyToMono(KakaoUserInfoResponse.class)
-                .onErrorMap(throwable -> new KakaoException(KakaoErrorCode.KAKAO_SERVER_CALL_FAILED))
-                .block();
+        return kakaoApiWebClient.get()
+            .uri("/v2/user/me")
+            .headers(headers -> headers.setBearerAuth(accessToken))
+            .retrieve()
+            .onStatus(
+                status -> status.is4xxClientError() || status.is5xxServerError(),
+                response -> response.bodyToMono(String.class)
+                    .flatMap(errorBody -> {
+                        if (response.statusCode().is4xxClientError()) {
+                            return Mono.error(new KakaoException(KakaoErrorCode.KAKAO_REQUEST_FAILED));
+                        }
+                        return Mono.error(new KakaoException(KakaoErrorCode.KAKAO_SERVER_ERROR));
+                    })
+            )
+            .bodyToMono(KakaoUserInfoResponse.class)
+            .onErrorMap(
+                throwable -> !(throwable instanceof BusinessException),
+                throwable -> new KakaoException(KakaoErrorCode.KAKAO_CONNECTION_FAILED)
+            )
+            .block();
     }
 } 

--- a/src/main/java/com/ridingmate/api_server/infra/kakao/KakaoConfig.java
+++ b/src/main/java/com/ridingmate/api_server/infra/kakao/KakaoConfig.java
@@ -22,7 +22,14 @@ public class KakaoConfig {
     }
 
     @Bean
-    public KakaoClient kakaoClient(WebClient kakaoWebClient) {
-        return new KakaoClient(kakaoWebClient);
+    public WebClient kakaoApiWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://kapi.kakao.com")
+                .build();
+    }
+
+    @Bean
+    public KakaoClient kakaoClient(WebClient kakaoWebClient, WebClient kakaoApiWebClient) {
+        return new KakaoClient(kakaoWebClient, kakaoApiWebClient);
     }
 } 

--- a/src/main/java/com/ridingmate/api_server/infra/kakao/KakaoErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/infra/kakao/KakaoErrorCode.java
@@ -8,10 +8,29 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum KakaoErrorCode implements ErrorCode {
-    KAKAO_SERVER_CALL_FAILED(HttpStatus.BAD_GATEWAY, "KAKAO_SERVER_CALL_FAILED", "외부 카카오 서버와의 통신에 실패했습니다."),
-    KAKAO_MAPPING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "KAKAO_MAPPING_FAILED", "카카오 응답 매핑에 실패했습니다."),
-    KAKAO_INVALID_COORDINATE(HttpStatus.BAD_GATEWAY, "KAKAO_INVALID_COORDINATE", "카카오 API 응답의 좌표값이 올바르지 않습니다."),
-    ;
+
+    /**
+     * 우리 서버의 로직 또는 설정 오류로 인해 Kakao가 4xx 에러를 반환한 경우.
+     * 사용자에게는 500 Internal Server Error로 응답해야 함.
+     */
+    KAKAO_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "KAKAO_REQUEST_FAILED", "Kakao API 요청 생성 실패"),
+
+    /**
+     * Kakao 서버가 5xx 에러로 응답한 경우. (Kakao 서버 내부 오류)
+     */
+    KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "KAKAO_SERVER_ERROR", "Kakao 서버 내부 오류 발생"),
+
+    /**
+     * Kakao 서버에 연결할 수 없거나 응답 시간 초과 등 네트워크 문제 발생.
+     */
+    KAKAO_CONNECTION_FAILED(HttpStatus.GATEWAY_TIMEOUT, "KAKAO_CONNECTION_FAILED", "Kakao 서버 연결 실패"),
+
+    /**
+     * Kakao API의 응답 데이터는 정상적으로 받았으나, 내용(e.g., 좌표값)이
+     * 우리 시스템의 비즈니스 규칙에 맞지 않아 처리에 실패한 경우.
+     */
+    KAKAO_INVALID_COORDINATE(HttpStatus.INTERNAL_SERVER_ERROR, "KAKAO_INVALID_COORDINATE", "카카오 응답 데이터의 좌표값이 유효하지 않습니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ridingmate/api_server/infra/ors/OrsClient.java
+++ b/src/main/java/com/ridingmate/api_server/infra/ors/OrsClient.java
@@ -1,10 +1,18 @@
 package com.ridingmate.api_server.infra.ors;
 
+import com.ridingmate.api_server.global.exception.BusinessException;
 import com.ridingmate.api_server.infra.ors.dto.request.OrsRouteRequest;
 import com.ridingmate.api_server.infra.ors.dto.response.OrsRouteResponse;
+import io.netty.handler.timeout.ReadTimeoutException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.codec.CodecException;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
 
+@Slf4j
 @RequiredArgsConstructor
 public class OrsClient {
 
@@ -15,9 +23,28 @@ public class OrsClient {
                 .uri("/v2/directions/cycling-regular/geojson")
                 .bodyValue(request)
                 .retrieve()
+                .onStatus(
+                    status -> status.is4xxClientError() || status.is5xxServerError(),
+                    response -> response.bodyToMono(String.class)
+                        .flatMap(errorBody -> {
+                            //4xx, 5xx 에러 처리
+                            if (response.statusCode().is4xxClientError()) {
+                                return Mono.error(new OrsException(OrsErrorCode.ORS_REQUEST_FAILED));
+                            }
+                            return Mono.error(new OrsException(OrsErrorCode.ORS_SERVER_ERROR));
+                        })
+                )
                 .bodyToMono(OrsRouteResponse.class)
                 .onErrorMap(
-                        throwable -> new OrsException(OrsErrorCode.ORS_SERVER_CALL_FAILED)
+                    throwable -> !(throwable instanceof BusinessException),
+                    throwable -> {
+                        if (throwable instanceof CodecException) {
+                            log.error("[ORS] API Response Mapping Failed", throwable);
+                            return new OrsException(OrsErrorCode.ORS_MAPPING_FAILED);
+                        }
+                        log.error("[ORS] API Call - Network or Unknown Error", throwable);
+                        return new OrsException(OrsErrorCode.ORS_CONNECTION_FAILED);
+                    }
                 )
                 .block();
     }

--- a/src/main/java/com/ridingmate/api_server/infra/ors/OrsErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/infra/ors/OrsErrorCode.java
@@ -8,9 +8,25 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum OrsErrorCode implements ErrorCode {
-    ORS_SERVER_CALL_FAILED(HttpStatus.BAD_GATEWAY, "ORS_502", "외부 ORS 서버와의 통신에 실패했습니다."),
-    ORS_MAPPING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ORS_002", "ORS 응답 매핑에 실패했습니다."),
-    ;
+
+    ORS_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ORS_REQUEST_FAILED", "ORS API 요청 생성 실패"),
+
+    /**
+     * ORS 서버가 5xx 에러로 응답한 경우. (ORS 서버 내부 오류)
+     */
+    ORS_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "ORS_SERVER_ERROR", "ORS 서버 내부 오류 발생"),
+    /**
+     * ORS 서버에 연결할 수 없거나 응답 시간 초과 등 네트워크 문제 발생.
+     */
+    ORS_CONNECTION_FAILED(HttpStatus.GATEWAY_TIMEOUT, "ORS_CONNECTION_FAILED", "ORS 서버 연결 실패"),
+
+    /**
+     * ORS API의 응답은 200 OK였으나, 응답 본문을 파싱(매핑)하는 데 실패한 경우.
+     * ORS API의 스펙이 변경되었거나, 예기치 않은 응답이 왔을 때 발생.
+     * 사용자에게는 500 Internal Server Error로 응답해야 함.
+     */
+    ORS_MAPPING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ORS_MAPPING_FAILED", "ORS 응답 처리 실패");
+
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
기존에 각 외부 API(ORS, Geoapify, Kakao) 클라이언트마다 제각각이었던 예외 처리 방식을 통일하고, Swagger에 표시되는 오류 응답의 가독성을 높여 API 명세의 완성도를 개선했습니다.

이를 통해 장애 발생 시 원인 파악을 용이하게 하고, 향후 새로운 외부 API 클라이언트를 추가할 때 일관된 패턴을 적용할 수 있도록 하여 유지보수성을 향상시켰습니다.

1. 외부 API 클라이언트 예외 처리 패턴 표준화
모든 외부 API 클라이언트(OrsClient, GeoapifyClient, KakaoClient)에 onStatus + onErrorMap 예외 처리 패턴을 일관되게 적용했습니다.
2. Swagger 오류 응답 문서 개선
ErrorCodeCustomizer 로직을 수정하여, 각 API에서 발생 가능한 오류 응답에 대해 상태 코드별로 상세한 설명을 추가했습니다.
이제 Swagger UI에서 각 HTTP 상태 코드(e.g., 400, 401)가 어떤 에러 코드(ErrorCode)들을 포함하는지, 그리고 각 에러 코드의 의미가 무엇인지 한눈에 파악할 수 있습니다.
3. 인증/인가 오류 코드 명확화
SecurityContext의 사용자를 DB에서 찾지 못하는 경우, UserErrorCode가 아닌 AuthErrorCode에서 처리하도록 책임을 명확히 분리했습니다. (AUTHENTICATION_USER_NOT_FOUND)
AuthErrorCode의 code 값을 Enum 상수명과 통일하여 가독성과 일관성을 높였습니다.

## PR 포인트

## 고민과 학습내용

## 스크린샷
<img width="705" height="750" alt="image" src="https://github.com/user-attachments/assets/0afc0c9d-3917-42ba-aed0-d02f40c76c63" />

