### PR TITLE
[Feat] 경로 데이터 상세 정보 확인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,6 @@ configurations {
 	}
 }
 
-repositories {
-	mavenCentral()
-}
-
 ext {
 	set('snippetsDir', file("build/generated-snippets"))
 }
@@ -70,6 +66,9 @@ dependencies {
 
 	//s3
 	implementation 'software.amazon.awssdk:s3:2.25.64'
+
+	//algorithms
+	implementation 'com.github.ggalmazor:lttb_downsampling:1.1.0'
 }
 
 bootJar {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
 rootProject.name = 'api-server'
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        maven { url 'https://jitpack.io' } // <-- 이 라인을 추가
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteApi.java
@@ -81,6 +81,22 @@ public interface RouteApi {
     ResponseEntity<CommonResponse<RouteListResponse>> getRouteList(@ModelAttribute RouteListRequest request);
 
     @Operation(
+            summary = "경로 상세 정보 조회",
+            description = """
+                    특정 경로(Route)의 상세 정보를 조회합니다.
+                                        
+                    - 경로의 기본 정보(이름, 설명, 거리, 고도 등)
+                    - 경로를 구성하는 모든 GPS 좌표 목록 (위도, 경도, 고도)
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공: 경로 상세 정보 조회 완료"),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없는 경로입니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 경로입니다."),
+    })
+    ResponseEntity<CommonResponse<RouteDetailResponse>> getRouteDetail(@Parameter(description = "경로 ID") @PathVariable Long routeId);
+
+    @Operation(
             summary = "지도 장소 검색",
             description = """
                     카카오 API를 통해 특정 위치 주변의 장소를 검색합니다.

--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
@@ -72,6 +72,18 @@ public class RouteController implements RouteApi{
     }
 
     @Override
+    @GetMapping("/{routeId}")
+    @ApiErrorCodeExample(RouteCommonErrorCode.class)
+    public ResponseEntity<CommonResponse<RouteDetailResponse>> getRouteDetail(
+        @PathVariable Long routeId
+    ) {
+        RouteDetailResponse response = routeFacade.getRouteDetail(routeId);
+        return ResponseEntity
+            .status(RouteSuccessCode.ROUTE_DETAIL_FETCHED.getStatus())
+            .body(CommonResponse.success(RouteSuccessCode.ROUTE_DETAIL_FETCHED, response));
+    }
+
+    @Override
     @GetMapping("/search")
     @ApiErrorCodeExample(KakaoErrorCode.class)
     public ResponseEntity<CommonResponse<MapSearchResponse>> getMapSearch(

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteDetailResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteDetailResponse.java
@@ -1,6 +1,7 @@
 package com.ridingmate.api_server.domain.route.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ggalmazor.ltdownsampling.Point;
 import com.ridingmate.api_server.domain.route.entity.Route;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -39,14 +40,10 @@ public record RouteDetailResponse(
 
     Integer trackPointsCount,
 
-    @Schema(
-        description = "샘플링된 경로의 주요 지점 목록",
-        example = "[{\"latitude\": 37.5519, \"longitude\": 126.9882, \"elevation\": 80.5}, {\"latitude\": 37.5525, \"longitude\": 126.9885, \"elevation\": 81.2}]"
-    )
-    List<RouteGpsPoint> trackPoints
+    List<Point> trackPoints
 ) {
 
-    public static RouteDetailResponse from(Route route, List<RouteGpsPoint> routeGpsPoints){
+    public static RouteDetailResponse from(Route route, List<Point> routeGpsPoints){
         return new RouteDetailResponse(
             route.getId(),
             route.getTitle(),

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteDetailResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteDetailResponse.java
@@ -1,0 +1,64 @@
+package com.ridingmate.api_server.domain.route.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ridingmate.api_server.domain.route.entity.Route;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record RouteDetailResponse(
+    @Schema(description = "경로 ID", example = "1")
+    Long id,
+
+    @Schema(description = "경로 제목", example = "한강 라이딩 경로")
+    String title,
+
+    @Schema(description = "경로 생성일", example = "2024-01-15T10:30:00")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    LocalDateTime createdAt,
+
+    @Schema(description = "예상 소요시간(min)", example = "71")
+    Duration duration,
+
+    @Schema(description = "이동 거리 (km)", example = "13.2")
+    Double distance,
+
+    @Schema(description = "총 상승 고도 (m)", example = "120.4")
+    Double elevationGain,
+
+    @Schema(description = "사용자 ID", example = "1")
+    Long userId,
+
+    @Schema(description = "사용자 닉네임", example = "라이더123")
+    String nickname,
+
+    @Schema(description = "프로필 이미지 URL", example = "https://s3.amazonaws.com/bucket/profile-1.jpg")
+    String profileImageUrl,
+
+    Integer trackPointsCount,
+
+    @Schema(
+        description = "샘플링된 경로의 주요 지점 목록",
+        example = "[{\"latitude\": 37.5519, \"longitude\": 126.9882, \"elevation\": 80.5}, {\"latitude\": 37.5525, \"longitude\": 126.9885, \"elevation\": 81.2}]"
+    )
+    List<RouteGpsPoint> trackPoints
+) {
+
+    public static RouteDetailResponse from(Route route, List<RouteGpsPoint> routeGpsPoints){
+        return new RouteDetailResponse(
+            route.getId(),
+            route.getTitle(),
+            route.getCreatedAt(),
+            route.getDuration(),
+            route.getDistance(),
+            route.getElevationGain(),
+            route.getUser().getId(),
+            route.getUser().getNickname(),
+            route.getUser().getProfileImagePath(),
+            routeGpsPoints.size(),
+            routeGpsPoints
+        );
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteGpsPoint.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteGpsPoint.java
@@ -1,0 +1,15 @@
+package com.ridingmate.api_server.domain.route.dto.response;
+
+import org.locationtech.jts.geom.Coordinate;
+
+public record RouteGpsPoint(
+    Double latitude,
+    Double longitude,
+    Double elevation
+) {
+
+    public static RouteGpsPoint from(Coordinate coordinate) {
+        Double elevation = Double.isNaN(coordinate.getZ()) ? null : coordinate.getZ();
+        return new RouteGpsPoint(coordinate.getY(), coordinate.getX(), elevation);
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGpsLog.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGpsLog.java
@@ -1,0 +1,35 @@
+package com.ridingmate.api_server.domain.route.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "route_gps_logs")
+public class RouteGpsLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "route_id", nullable = false)
+    private Route route;
+
+    @Column(name = "log_time", nullable = false)
+    private LocalDateTime logTime;
+
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private Double longitude;
+
+    @Column(name = "elevation")
+    private Double elevation;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteException.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteException.java
@@ -1,7 +1,9 @@
 package com.ridingmate.api_server.domain.route.exception;
 
+import com.ridingmate.api_server.domain.route.entity.Route;
 import com.ridingmate.api_server.domain.route.exception.code.RouteCommonErrorCode;
 import com.ridingmate.api_server.domain.route.exception.code.RouteCreationErrorCode;
+import com.ridingmate.api_server.domain.route.exception.code.RouteDetailErrorCode;
 import com.ridingmate.api_server.domain.route.exception.code.RouteShareErrorCode;
 import com.ridingmate.api_server.global.exception.BusinessException;
 
@@ -16,6 +18,10 @@ public class RouteException extends BusinessException {
     }
 
     public RouteException(RouteCreationErrorCode errorCode){
+        super(errorCode);
+    }
+
+    public RouteException(RouteDetailErrorCode errorCode){
         super(errorCode);
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteSuccessCode.java
@@ -12,7 +12,8 @@ public enum RouteSuccessCode implements SuccessCode {
     ROUTE_CREATED(HttpStatus.CREATED, "경로가 생성되었습니다."),
     SHARE_LINK_FETCHED(HttpStatus.OK, "경로 공유 링크가 조회되었습니다."),
     ROUTE_LIST_FETCHED(HttpStatus.OK, "경로 목록이 조회되었습니다."),
-    MAP_SEARCH_FETCHED(HttpStatus.OK, "장소 검색 결과 목록이 조회되었습니다.")
+    MAP_SEARCH_FETCHED(HttpStatus.OK, "장소 검색 결과 목록이 조회되었습니다."),
+    ROUTE_DETAIL_FETCHED(HttpStatus.OK, "경로 세부 정보가 조회되었습니다."),
     ;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/code/RouteDetailErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/code/RouteDetailErrorCode.java
@@ -1,0 +1,17 @@
+package com.ridingmate.api_server.domain.route.exception.code;
+
+import com.ridingmate.api_server.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RouteDetailErrorCode implements ErrorCode {
+    ROUTE_GPS_LOGS_INVALID(HttpStatus.UNPROCESSABLE_ENTITY, "ROUTE_GPS_LOGS_INVALID", "경로의 좌표가 2개 미만으로 불충분합니다"),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
@@ -17,10 +17,12 @@ import com.ridingmate.api_server.infra.ors.OrsMapper;
 import com.ridingmate.api_server.infra.ors.dto.response.OrsRouteResponse;
 import com.ridingmate.api_server.global.util.GeometryUtil;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Component
@@ -77,6 +79,17 @@ public class RouteFacade {
             .toList();
 
         return RouteListResponse.of(routeItems, routePage);
+    }
+
+    public RouteDetailResponse getRouteDetail(Long routeId){
+        Coordinate[] coordinates = routeService.getRouteDetailList(routeId);
+        Route route = routeService.getRouteWithUser(routeId);
+//        List<Coordinate> simplifiedRouteGpsLogs = GeometryUtil.simplifyRoute(coordinates);
+        List<Coordinate> simplifiedRouteGpsLogs = Arrays.stream(coordinates).toList();
+        List<RouteGpsPoint> routeGpsLogs = simplifiedRouteGpsLogs.stream()
+            .map(RouteGpsPoint::from)
+            .toList();
+        return RouteDetailResponse.from(route, routeGpsLogs);
     }
 
     public MapSearchResponse getMapSearch(String query, Double lon, Double lat) {

--- a/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteGpsLogRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteGpsLogRepository.java
@@ -1,0 +1,12 @@
+package com.ridingmate.api_server.domain.route.repository;
+
+import com.ridingmate.api_server.domain.route.entity.RouteGpsLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RouteGpsLogRepository extends JpaRepository<RouteGpsLog, Long> {
+    List<RouteGpsLog> findByRouteIdOrderByLogTimeAsc(Long routeId);
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteRepository.java
@@ -14,9 +14,18 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RouteRepository extends JpaRepository<Route, Long> {
+
+    @Query("""
+        SELECT r
+        FROM Route r
+        JOIN FETCH r.user
+        WHERE r.id = :routeId
+        """)
+    Optional<Route> findRouteWithUser(@Param("routeId") Long routeId);
 
     /**
      * 사용자별 특정 관계 타입의 경로 조회 (거리 및 고도 필터링 포함)

--- a/src/main/java/com/ridingmate/api_server/global/util/GeometryUtil.java
+++ b/src/main/java/com/ridingmate/api_server/global/util/GeometryUtil.java
@@ -1,12 +1,17 @@
 package com.ridingmate.api_server.global.util;
 
+import com.ggalmazor.ltdownsampling.DoublePoint;
+import com.ggalmazor.ltdownsampling.LTThreeBuckets;
+import com.ggalmazor.ltdownsampling.Point;
 import com.ridingmate.api_server.domain.route.exception.RouteException;
 import com.ridingmate.api_server.domain.route.exception.code.RouteCreationErrorCode;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class GeometryUtil {
 
@@ -144,5 +149,21 @@ public class GeometryUtil {
         Coordinate[] simplifiedCoords = simplifier.getResultGeometry().getCoordinates();
 
         return List.of(simplifiedCoords);
+    }
+
+    public static List<Point> convertCoordinatesToPoints(List<Coordinate> coordinates){
+        if (coordinates == null || coordinates.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return IntStream.range(0, coordinates.size())
+            .mapToObj(i -> {
+                Coordinate coordinate = coordinates.get(i);
+
+                double elevation = Double.isNaN(coordinate.getZ()) ? 0.0 : coordinate.getZ();
+
+                return new DoublePoint(i, elevation);
+            })
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/ridingmate/api_server/global/util/GeometryUtil.java
+++ b/src/main/java/com/ridingmate/api_server/global/util/GeometryUtil.java
@@ -2,8 +2,8 @@ package com.ridingmate.api_server.global.util;
 
 import com.ridingmate.api_server.domain.route.exception.RouteException;
 import com.ridingmate.api_server.domain.route.exception.code.RouteCreationErrorCode;
-import com.ridingmate.api_server.global.exception.BusinessException;
 import org.locationtech.jts.geom.*;
+import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,6 +11,8 @@ import java.util.stream.Collectors;
 public class GeometryUtil {
 
     private static final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+    private static final double DISTANCE_TOLERANCE = 0.00000000001;
 
     /**
      * Encoded polyline을 LineString으로 변환 예시: LINESTRING (126.9706 37.5547, 127.0276 37.4979, ...)
@@ -73,12 +75,6 @@ public class GeometryUtil {
         return zoomLevel;
     }
 
-    public static int getZoomLevelFromPolyline(String polyline) {
-        LineString line = polylineToLineString(polyline);
-        Envelope bbox = getBoundingBox(line);
-        return getZoomLevel(bbox);
-    }
-
     /**
      * Coordinates 리스트를 Geoapify geometry 파라미터용 polyline 문자열로 변환
      * 예: polyline:127.0535,37.53560,127.05349,37.53559 ...
@@ -138,5 +134,15 @@ public class GeometryUtil {
 
         // 소수점 2자리로 반올림
         return Math.round(distance * 100.0) / 100.0;
+    }
+    public static List<Coordinate> simplifyRoute(Coordinate[] coordinates) {
+        LineString lineString = geometryFactory.createLineString(coordinates);
+
+        DouglasPeuckerSimplifier simplifier = new DouglasPeuckerSimplifier(lineString);
+        simplifier.setDistanceTolerance(DISTANCE_TOLERANCE);
+
+        Coordinate[] simplifiedCoords = simplifier.getResultGeometry().getCoordinates();
+
+        return List.of(simplifiedCoords);
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
경로의 상세 정보를 조회하는 API GET /api/routes/{routeId}를 구현했습니다.

이 API는 경로의 기본 정보(이름, 거리, 난이도 등)와 함께, 해당 경로를 구성하는 모든 GPS 좌표 목록(위도, 경도, 고도)을 반환합니다.

대용량 GPS 데이터(trackPoints)를 효율적으로 클라이언트에 전달하기 위해, 향후 데이터 샘플링(LTTB) 적용을 고려한 구조로 설계되었습니다.

현재 그래프의 x좌표 개수를 300개를 기준으로 샘플링 했으며 추후 테스트를 해보며 적절한 x좌표 개수 혹은 동적으로 설계하여 수정이 필요해보입니다.

## PR 포인트

## 고민과 학습내용

## 스크린샷
