### PR TITLE
[Feat] 사용자 프로필 조회 및 수정 관련 API

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteApi.java
@@ -1,5 +1,6 @@
 package com.ridingmate.api_server.domain.route.controller;
 
+import com.ridingmate.api_server.domain.auth.security.AuthUser;
 import com.ridingmate.api_server.domain.route.dto.request.CreateRouteRequest;
 import com.ridingmate.api_server.domain.route.dto.request.RouteListRequest;
 import com.ridingmate.api_server.domain.route.dto.request.RouteSegmentRequest;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,7 +26,8 @@ public interface RouteApi {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "성공: 세그먼트 생성 완료"),
     })
-    ResponseEntity<CommonResponse<RouteSegmentResponse>> previewRoute(@RequestBody RouteSegmentRequest request);
+    ResponseEntity<CommonResponse<RouteSegmentResponse>> previewRoute(
+            @RequestBody RouteSegmentRequest request);
 
     @Operation(
             summary = "경로 생성 및 저장",
@@ -41,7 +44,9 @@ public interface RouteApi {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "성공: 경로 생성 완료"),
     })
-    ResponseEntity<CommonResponse<CreateRouteResponse>> createRoute(@Valid @RequestBody CreateRouteRequest request);
+    ResponseEntity<CommonResponse<CreateRouteResponse>> createRoute(
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody CreateRouteRequest request);
 
     @Operation(
             summary = "경로 공유 링크 조회",
@@ -53,7 +58,9 @@ public interface RouteApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공: 공유 링크 조회 완료"),
     })
-    ResponseEntity<CommonResponse<ShareRouteResponse>> shareRoute(@PathVariable Long routeId);
+    ResponseEntity<CommonResponse<ShareRouteResponse>> shareRoute(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long routeId);
 
     @Operation(
             summary = "내 경로 목록 조회",
@@ -78,7 +85,9 @@ public interface RouteApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공: 경로 목록 조회 완료"),
     })
-    ResponseEntity<CommonResponse<RouteListResponse>> getRouteList(@ModelAttribute RouteListRequest request);
+    ResponseEntity<CommonResponse<RouteListResponse>> getRouteList(
+            @AuthenticationPrincipal AuthUser authUser,
+            @ModelAttribute RouteListRequest request);
 
     @Operation(
             summary = "경로 상세 정보 조회",
@@ -94,7 +103,9 @@ public interface RouteApi {
             @ApiResponse(responseCode = "403", description = "접근 권한이 없는 경로입니다."),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 경로입니다."),
     })
-    ResponseEntity<CommonResponse<RouteDetailResponse>> getRouteDetail(@Parameter(description = "경로 ID") @PathVariable Long routeId);
+    ResponseEntity<CommonResponse<RouteDetailResponse>> getRouteDetail(
+            @Parameter(description = "경로 ID")
+            @PathVariable Long routeId);
 
     @Operation(
             summary = "지도 장소 검색",

--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
@@ -1,6 +1,7 @@
 package com.ridingmate.api_server.domain.route.controller;
 
 import com.ridingmate.api_server.domain.auth.exception.AuthErrorCode;
+import com.ridingmate.api_server.domain.auth.security.AuthUser;
 import com.ridingmate.api_server.domain.route.dto.request.CreateRouteRequest;
 import com.ridingmate.api_server.domain.route.dto.request.RouteListRequest;
 import com.ridingmate.api_server.domain.route.dto.request.RouteSegmentRequest;
@@ -16,6 +17,7 @@ import com.ridingmate.api_server.infra.ors.OrsErrorCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -40,8 +42,10 @@ public class RouteController implements RouteApi{
     @PostMapping
     @ApiErrorCodeExample(RouteCreationErrorCode.class)
     @ApiErrorCodeExample(AuthErrorCode.class)
-    public ResponseEntity<CommonResponse<CreateRouteResponse>> createRoute(@Valid @RequestBody CreateRouteRequest request) {
-        CreateRouteResponse response = routeFacade.createRoute(request);
+    public ResponseEntity<CommonResponse<CreateRouteResponse>> createRoute(
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody CreateRouteRequest request) {
+        CreateRouteResponse response = routeFacade.createRoute(authUser, request);
         return ResponseEntity.
                 status(RouteSuccessCode.ROUTE_CREATED.getStatus())
                 .body(CommonResponse.success(RouteSuccessCode.ROUTE_CREATED, response));
@@ -50,8 +54,10 @@ public class RouteController implements RouteApi{
     @Override
     @GetMapping("/{routeId}/share")
     @ApiErrorCodeExample(RouteCommonErrorCode.class)
-    public ResponseEntity<CommonResponse<ShareRouteResponse>> shareRoute(@PathVariable Long routeId) {
-        ShareRouteResponse  response = routeFacade.shareRoute(routeId);
+    public ResponseEntity<CommonResponse<ShareRouteResponse>> shareRoute(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long routeId) {
+        ShareRouteResponse  response = routeFacade.shareRoute(authUser, routeId);
         return ResponseEntity
                 .status(RouteSuccessCode.SHARE_LINK_FETCHED.getStatus())
                 .body(CommonResponse.success(RouteSuccessCode.SHARE_LINK_FETCHED, response));
@@ -60,12 +66,10 @@ public class RouteController implements RouteApi{
     @Override
     @GetMapping
     public ResponseEntity<CommonResponse<RouteListResponse>> getRouteList(
+            @AuthenticationPrincipal AuthUser authUser,
             @ModelAttribute RouteListRequest request
     ) {
-        // TODO: 실제 사용자 인증 구현 후 수정 필요
-        Long userId = 1L; // 현재는 mockUser 사용
-        
-        RouteListResponse response = routeFacade.getRouteList(userId, request);
+        RouteListResponse response = routeFacade.getRouteList(authUser, request);
         return ResponseEntity
                 .status(RouteSuccessCode.ROUTE_LIST_FETCHED.getStatus())
                 .body(CommonResponse.success(RouteSuccessCode.ROUTE_LIST_FETCHED, response));

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/request/CreateRouteRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/request/CreateRouteRequest.java
@@ -34,12 +34,23 @@ public record CreateRouteRequest(
         @NotNull
         Double elevationGain,
 
-        @Schema(description = "고도 정보 목록", example = "[20.5, 25.0, 30.2]")
-        List<Double> elevations,
+        @Schema(description = "위도, 경도, 고도 정보 목록", example = "[[126.91331, 37,603735, 27.5], [126.913349, 37.603735, 27.5]")
+        List<Position> geometry,
 
         @Schema(
                 description = "경로 Bounding Box 좌표 [minLon, minLat, maxLon, maxLat]",
                 example = "[127.01, 37.50, 127.05, 37.55]"
         )
         List<Double> bbox
-) {}
+) {
+        public record Position(
+                @Schema(description = "경도 정보")
+                Double longitude,
+
+                @Schema(description = "위도 정보")
+                Double latitude,
+
+                @Schema(description = "고도 정보")
+                Double elevation
+        ){}
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGeometry.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGeometry.java
@@ -44,7 +44,7 @@ public class RouteGeometry {
     private LineString routeLine;
 
     @Builder
-    public RouteGeometry(Long id, Route route, String gpxFilePath, double maxLat, double maxLon, double minLat, double minLon, LineString routeLine) {
+    private RouteGeometry(Long id, Route route, String gpxFilePath, double maxLat, double maxLon, double minLat, double minLon, LineString routeLine) {
         this.id = id;
         this.route = route;
         this.gpxFilePath = gpxFilePath;

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGpsLog.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGpsLog.java
@@ -2,6 +2,7 @@ package com.ridingmate.api_server.domain.route.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,12 +25,21 @@ public class RouteGpsLog {
     @Column(name = "log_time", nullable = false)
     private LocalDateTime logTime;
 
-    @Column(name = "latitude", nullable = false)
-    private Double latitude;
-
     @Column(name = "longitude", nullable = false)
     private Double longitude;
 
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;
+
     @Column(name = "elevation")
     private Double elevation;
+
+    @Builder
+    private RouteGpsLog(Route route, Double longitude, Double latitude, Double elevation, LocalDateTime logTime){
+        this.route = route;
+        this.longitude = longitude;
+        this.latitude = latitude;
+        this.elevation = elevation;
+        this.logTime = logTime;
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
@@ -48,6 +48,11 @@ public class RouteFacade {
         LineString routeLine = GeometryUtil.polylineToLineString(request.polyline());
         byte[] thumbnailBytes = geoapifyClient.getStaticMap(routeLine);
         Route route = routeService.createRoute(request, routeLine);
+
+        Coordinate[] geometry = request.geometry().stream()
+                .map(dto -> new Coordinate(dto.longitude(), dto.latitude(), dto.elevation()))
+                .toArray(Coordinate[]::new);
+
         s3Manager.uploadByteFiles(route.getThumbnailImagePath(), thumbnailBytes);
 
         return CreateRouteResponse.from(route);

--- a/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
@@ -50,8 +50,8 @@ public class RouteService {
     private final RouteGpsLogRepository routeGpsLogRepository;
 
     @Transactional
-    public Route createRoute(CreateRouteRequest request, LineString routeLine) {
-        User user = userRepository.findById(1L)
+    public Route createRoute(Long userId, CreateRouteRequest request, LineString routeLine) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.AUTHENTICATION_USER_NOT_FOUND));
 
         // Route 엔티티 생성

--- a/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
@@ -23,11 +23,14 @@ import com.ridingmate.api_server.global.util.GeometryUtil;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Position;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -62,6 +65,10 @@ public class RouteService {
                 .shareId(UUID.randomUUID().toString())
                 .build();
 
+        Coordinate[] geometry = request.geometry().stream()
+                .map(dto -> new Coordinate(dto.longitude(), dto.longitude(), dto.elevation()))
+                .toArray(Coordinate[]::new);
+        createRouteGpsLog(route, geometry);
         
         // RouteGeometry 엔티티 생성
         RouteGeometry routeGeometry = RouteGeometry.builder()
@@ -86,6 +93,29 @@ public class RouteService {
         createUserRouteRelation(user, route, RouteRelationType.OWNER);
 
         return route;
+    }
+
+    private void createRouteGpsLog(Route route, Coordinate[] geometry){
+        LocalDateTime baseTime = LocalDateTime.now();
+        int sequence = 0;
+
+        List<RouteGpsLog> routeGpsLogs = new ArrayList<>();
+        for (Coordinate coordinate: geometry){
+            LocalDateTime virtualLogTime = baseTime.plusSeconds(sequence);
+
+            RouteGpsLog routeGpsLog = RouteGpsLog.builder()
+                    .route(route)
+                    .longitude(coordinate.getX())
+                    .latitude(coordinate.getY())
+                    .elevation(coordinate.getZ())
+                    .logTime(virtualLogTime)
+                    .build();
+            routeGpsLogs.add(routeGpsLog);
+
+            sequence++;
+        }
+
+        routeGpsLogRepository.saveAll(routeGpsLogs);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ridingmate/api_server/domain/user/Gender.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/Gender.java
@@ -1,0 +1,7 @@
+package com.ridingmate.api_server.domain.user;
+
+public enum Gender {
+    MALE,
+    FEMALE,
+    OTHER
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/controller/UserApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/controller/UserApi.java
@@ -1,0 +1,63 @@
+package com.ridingmate.api_server.domain.user.controller;
+
+import com.ridingmate.api_server.domain.auth.security.AuthUser;
+import com.ridingmate.api_server.domain.user.dto.UserResponse;
+import com.ridingmate.api_server.domain.user.dto.request.BirthYearUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.GenderUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.IntroduceUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.NicknameUpdateRequest;
+import com.ridingmate.api_server.global.exception.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "User API", description = "사용자 관련 API")
+public interface UserApi {
+
+    @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 상세 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "성공: 사용자 정보 조회 완료")
+    @GetMapping("/user/profile")
+    ResponseEntity<CommonResponse<UserResponse>> getMyInfo(
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser
+    );
+
+    @Operation(summary = "닉네임 변경", description = "현재 로그인된 사용자의 닉네임을 변경합니다.")
+    @ApiResponse(responseCode = "200", description = "성공: 닉네임 변경 완료")
+    @PutMapping("/user/profile/nickname")
+    ResponseEntity<CommonResponse<UserResponse>> updateNickname(
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody NicknameUpdateRequest request
+    );
+
+    @Operation(summary = "한 줄 소개 변경", description = "현재 로그인된 사용자의 한 줄 소개를 변경합니다.")
+    @ApiResponse(responseCode = "200", description = "성공: 한 줄 소개 변경 완료")
+    @PutMapping("/user/profile/introduce")
+    ResponseEntity<CommonResponse<UserResponse>> updateIntroduce(
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody IntroduceUpdateRequest request
+    );
+
+    @Operation(summary = "성별 변경", description = "현재 로그인된 사용자의 성별을 변경합니다.")
+    @ApiResponse(responseCode = "200", description = "성공: 성별 변경 완료")
+    @PutMapping("/user/me/gender")
+    ResponseEntity<CommonResponse<UserResponse>> updateGender(
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody GenderUpdateRequest request
+    );
+
+    @Operation(summary = "출생년도 변경", description = "현재 로그인된 사용자의 출생년도를 변경합니다.")
+    @ApiResponse(responseCode = "200", description = "성공: 출생년도 변경 완료")
+    @PutMapping("/user/profile/birth")
+    ResponseEntity<CommonResponse<UserResponse>> updateBirthYear(
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody BirthYearUpdateRequest request
+    );
+
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/controller/UserController.java
@@ -1,0 +1,70 @@
+package com.ridingmate.api_server.domain.user.controller;
+
+import com.ridingmate.api_server.domain.auth.security.AuthUser;
+import com.ridingmate.api_server.domain.user.dto.UserResponse;
+import com.ridingmate.api_server.domain.user.dto.request.BirthYearUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.GenderUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.IntroduceUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.NicknameUpdateRequest;
+import com.ridingmate.api_server.domain.user.exception.UserSuccessCode;
+import com.ridingmate.api_server.domain.user.facade.UserFacade;
+import com.ridingmate.api_server.global.exception.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class UserController implements UserApi {
+
+    private final UserFacade userFacade;
+
+    @Override
+    @GetMapping("/user/profile")
+    public ResponseEntity<CommonResponse<UserResponse>> getMyInfo(AuthUser authUser) {
+        UserResponse response = userFacade.getMyInfo(authUser.id());
+        return ResponseEntity
+                .status(UserSuccessCode.GET_MY_INFO_SUCCESS.getStatus())
+                .body(CommonResponse.success(UserSuccessCode.GET_MY_INFO_SUCCESS, response));
+    }
+
+    @Override
+    @PutMapping("/user/profile/nickname")
+    public ResponseEntity<CommonResponse<UserResponse>> updateNickname(AuthUser authUser, NicknameUpdateRequest request) {
+        UserResponse response = userFacade.updateNickname(authUser.id(), request);
+        return ResponseEntity
+                .status(UserSuccessCode.UPDATE_NICKNAME_SUCCESS.getStatus())
+                .body(CommonResponse.success(UserSuccessCode.UPDATE_NICKNAME_SUCCESS, response));
+    }
+
+    @Override
+    @PutMapping("/user/profile/introduce")
+    public ResponseEntity<CommonResponse<UserResponse>> updateIntroduce(AuthUser authUser, IntroduceUpdateRequest request) {
+        UserResponse response = userFacade.updateIntroduce(authUser.id(), request);
+        return ResponseEntity
+                .status(UserSuccessCode.UPDATE_INTRODUCE_SUCCESS.getStatus())
+                .body(CommonResponse.success(UserSuccessCode.UPDATE_INTRODUCE_SUCCESS, response));
+    }
+
+    @Override
+    @PutMapping("/user/me/gender")
+    public ResponseEntity<CommonResponse<UserResponse>> updateGender(AuthUser authUser, GenderUpdateRequest request) {
+        UserResponse response = userFacade.updateGender(authUser.id(), request);
+        return ResponseEntity
+                .status(UserSuccessCode.UPDATE_GENDER_SUCCESS.getStatus())
+                .body(CommonResponse.success(UserSuccessCode.UPDATE_GENDER_SUCCESS, response));
+    }
+
+    @Override
+    @PutMapping("/user/profile/birth")
+    public ResponseEntity<CommonResponse<UserResponse>> updateBirthYear(AuthUser authUser, BirthYearUpdateRequest request) {
+        UserResponse response = userFacade.updateBirthYear(authUser.id(), request);
+        return ResponseEntity
+                .status(UserSuccessCode.UPDATE_BIRTH_YEAR_SUCCESS.getStatus())
+                .body(CommonResponse.success(UserSuccessCode.UPDATE_BIRTH_YEAR_SUCCESS, response));
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/dto/UserResponse.java
@@ -1,0 +1,43 @@
+package com.ridingmate.api_server.domain.user.dto;
+
+import com.ridingmate.api_server.domain.user.entity.User;
+import com.ridingmate.api_server.domain.user.enums.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "사용자 정보 응답 DTO")
+public record UserResponse(
+        @Schema(description = "사용자 고유 식별자(UUID)", example = "a1b2c3d4-e5f6-7890-1234-567890abcdef")
+        UUID uuid,
+
+        @Schema(description = "닉네임", example = "라이딩메이트")
+        String nickname,
+
+        @Schema(description = "이메일 주소", example = "test@ridingmate.com")
+        String email,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/images/profile.jpg")
+        String profileImagePath,
+
+        @Schema(description = "자기소개", example = "한강 라이딩을 즐겨요!")
+        String introduce,
+
+        @Schema(description = "출생년도", example = "1990")
+        Integer birthYear,
+
+        @Schema(description = "성별", example = "MALE")
+        Gender gender
+) {
+    public static UserResponse from(User user) {
+        return new UserResponse(
+                user.getUuid(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getProfileImagePath(),
+                user.getIntroduce(),
+                user.getBirthYear(),
+                user.getGender()
+        );
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/dto/request/BirthYearUpdateRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/dto/request/BirthYearUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.ridingmate.api_server.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "출생년도 변경 요청 DTO")
+public record BirthYearUpdateRequest(
+        @NotNull(message = "출생년도를 입력해주세요.")
+        @Min(value = 1900, message = "유효한 출생년도를 입력해주세요.")
+        @Max(value = 2024, message = "유효한 출생년도를 입력해주세요.")
+        @Schema(description = "새로운 출생년도", example = "1995")
+        Integer birthYear
+) {
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/dto/request/GenderUpdateRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/dto/request/GenderUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.ridingmate.api_server.domain.user.dto.request;
+
+import com.ridingmate.api_server.domain.user.enums.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "성별 변경 요청 DTO")
+public record GenderUpdateRequest(
+        @NotNull(message = "성별을 입력해주세요.")
+        @Schema(description = "새로운 성별", example = "MALE")
+        Gender gender
+) {
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/dto/request/IntroduceUpdateRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/dto/request/IntroduceUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.ridingmate.api_server.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "한 줄 소개 변경 요청 DTO")
+public record IntroduceUpdateRequest(
+        @Size(max = 100, message = "한 줄 소개는 100자 이하로 입력해주세요.")
+        @Schema(description = "새로운 한 줄 소개", example = "한강에서 주로 라이딩합니다!")
+        String introduce
+) {
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/dto/request/NicknameUpdateRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/dto/request/NicknameUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.ridingmate.api_server.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "닉네임 변경 요청 DTO")
+public record NicknameUpdateRequest(
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 입력해주세요.")
+        @Schema(description = "새로운 닉네임", example = "새로운닉네임")
+        String nickname
+) {
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/entity/User.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/entity/User.java
@@ -1,13 +1,17 @@
 package com.ridingmate.api_server.domain.user.entity;
 
+import com.ridingmate.api_server.domain.user.Gender;
 import com.ridingmate.api_server.global.entity.BaseTimeEntity;
 import com.ridingmate.api_server.domain.auth.enums.SocialProvider;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 
@@ -40,8 +44,20 @@ public class User extends BaseTimeEntity {
     @Column(name = "profile_image_path")
     private String profileImagePath;
 
+    @Column(name = "introduce")
+    private String introduce;
+
+    @Min(1900)
+    @Max(2025)
+    @Column(name = "birth_year")
+    private Integer birthYear;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender")
+    private Gender gender;
+
     @Builder
-    public User(SocialProvider socialProvider, String socialId, String email, 
+    public User(SocialProvider socialProvider, String socialId, String email,
                 String nickname, String profileImagePath) {
         this.socialProvider = socialProvider;
         this.socialId = socialId;

--- a/src/main/java/com/ridingmate/api_server/domain/user/entity/User.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/entity/User.java
@@ -1,6 +1,6 @@
 package com.ridingmate.api_server.domain.user.entity;
 
-import com.ridingmate.api_server.domain.user.Gender;
+import com.ridingmate.api_server.domain.user.enums.Gender;
 import com.ridingmate.api_server.global.entity.BaseTimeEntity;
 import com.ridingmate.api_server.domain.auth.enums.SocialProvider;
 import jakarta.persistence.*;
@@ -11,7 +11,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 
@@ -85,6 +84,34 @@ public class User extends BaseTimeEntity {
                 .nickname(nickname)
                 .profileImagePath(profileImagePath)
                 .build();
+    }
+
+    /**
+     * 닉네임 업데이트
+     */
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    /**
+     * 한 줄 소개 업데이트
+     */
+    public void updateIntroduce(String introduce) {
+        this.introduce = introduce;
+    }
+
+    /**
+     * 성별 업데이트
+     */
+    public void updateGender(Gender gender) {
+        this.gender = gender;
+    }
+
+    /**
+     * 출생년도 업데이트
+     */
+    public void updateBirthYear(Integer birthYear) {
+        this.birthYear = birthYear;
     }
 
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/enums/Gender.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/enums/Gender.java
@@ -1,4 +1,4 @@
-package com.ridingmate.api_server.domain.user;
+package com.ridingmate.api_server.domain.user.enums;
 
 public enum Gender {
     MALE,

--- a/src/main/java/com/ridingmate/api_server/domain/user/exception/UserSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/exception/UserSuccessCode.java
@@ -1,0 +1,21 @@
+package com.ridingmate.api_server.domain.user.exception;
+
+import com.ridingmate.api_server.global.exception.BaseCode;
+import com.ridingmate.api_server.global.exception.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserSuccessCode implements SuccessCode {
+
+    GET_MY_INFO_SUCCESS(HttpStatus.OK, "내 정보 조회 성공"),
+    UPDATE_NICKNAME_SUCCESS(HttpStatus.OK,  "닉네임 변경 성공"),
+    UPDATE_INTRODUCE_SUCCESS(HttpStatus.OK, "한 줄 소개 변경 성공"),
+    UPDATE_GENDER_SUCCESS(HttpStatus.OK, "성별 변경 성공"),
+    UPDATE_BIRTH_YEAR_SUCCESS(HttpStatus.OK, "출생년도 변경 성공");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
@@ -1,0 +1,43 @@
+package com.ridingmate.api_server.domain.user.facade;
+
+import com.ridingmate.api_server.domain.user.dto.UserResponse;
+import com.ridingmate.api_server.domain.user.dto.request.BirthYearUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.GenderUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.IntroduceUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.NicknameUpdateRequest;
+import com.ridingmate.api_server.domain.user.entity.User;
+import com.ridingmate.api_server.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserFacade {
+
+    private final UserService userService;
+
+    public UserResponse getMyInfo(Long userId) {
+        User user = userService.getMyInfo(userId);
+        return UserResponse.from(user);
+    }
+
+    public UserResponse updateNickname(Long userId, NicknameUpdateRequest request) {
+        User user = userService.updateNickname(userId, request);
+        return UserResponse.from(user);
+    }
+
+    public UserResponse updateIntroduce(Long userId, IntroduceUpdateRequest request) {
+        User user = userService.updateIntroduce(userId, request);
+        return UserResponse.from(user);
+    }
+
+    public UserResponse updateGender(Long userId, GenderUpdateRequest request) {
+        User user = userService.updateGender(userId, request);
+        return UserResponse.from(user);
+    }
+
+    public UserResponse updateBirthYear(Long userId, BirthYearUpdateRequest request) {
+        User user = userService.updateBirthYear(userId, request);
+        return UserResponse.from(user);
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/service/UserService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/service/UserService.java
@@ -1,21 +1,23 @@
 package com.ridingmate.api_server.domain.user.service;
 
+import com.ridingmate.api_server.domain.auth.dto.SocialUserInfo;
+import com.ridingmate.api_server.domain.user.dto.request.BirthYearUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.GenderUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.IntroduceUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.NicknameUpdateRequest;
 import com.ridingmate.api_server.domain.user.entity.User;
 import com.ridingmate.api_server.domain.user.exception.UserErrorCode;
 import com.ridingmate.api_server.domain.user.exception.UserException;
 import com.ridingmate.api_server.domain.user.repository.UserRepository;
-import com.ridingmate.api_server.domain.auth.dto.SocialUserInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * 사용자 관리 서비스
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserService {
 
     private final UserRepository userRepository;
@@ -30,7 +32,7 @@ public class UserService {
     public User findOrCreateUser(SocialUserInfo socialUserInfo) {
         // 기존 사용자 조회
         return userRepository.findBySocialProviderAndSocialId(
-                socialUserInfo.getProvider(), 
+                socialUserInfo.getProvider(),
                 socialUserInfo.getSocialId()
         ).orElseGet(() -> {
             // 새 사용자 생성
@@ -41,10 +43,10 @@ public class UserService {
                     socialUserInfo.getNickname(),
                     socialUserInfo.getProfileImageUrl()
             );
-            
+
             User savedUser = userRepository.save(newUser);
             log.info("새 사용자 생성 - ID: {}, 이메일: {}", savedUser.getId(), savedUser.getEmail());
-            
+
             return savedUser;
         });
     }
@@ -52,5 +54,34 @@ public class UserService {
     public User getUser(Long userId){
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public User getMyInfo(Long userId) {
+        return getUser(userId);
+    }
+
+    public User updateNickname(Long userId, NicknameUpdateRequest request) {
+        User user = getUser(userId);
+        user.updateNickname(request.nickname());
+        return user;
+    }
+
+    public User updateIntroduce(Long userId, IntroduceUpdateRequest request) {
+        User user = getUser(userId);
+        user.updateIntroduce(request.introduce());
+        return user;
+    }
+
+    public User updateGender(Long userId, GenderUpdateRequest request) {
+        User user = getUser(userId);
+        user.updateGender(request.gender());
+        return user;
+    }
+
+    public User updateBirthYear(Long userId, BirthYearUpdateRequest request) {
+        User user = getUser(userId);
+        user.updateBirthYear(request.birthYear());
+        return user;
     }
 } 

--- a/src/main/java/com/ridingmate/api_server/infra/terra/dto/request/TerraProviderAuthRequest.java
+++ b/src/main/java/com/ridingmate/api_server/infra/terra/dto/request/TerraProviderAuthRequest.java
@@ -2,11 +2,12 @@ package com.ridingmate.api_server.infra.terra.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.ridingmate.api_server.infra.terra.TerraProperty;
 
 import java.util.UUID;
 
 public record TerraProviderAuthRequest(
+        @JsonIgnore // provider는 쿼리 파라미터로 사용되므로 JSON 본문에는 포함되지 않도록 설정
+        String provider,
         String language,
         @JsonProperty("reference_id") String referenceId,
         @JsonProperty("auth_success_redirect_url") String authSuccessRedirectUrl,
@@ -25,6 +26,7 @@ public record TerraProviderAuthRequest(
         String failureUrl = appScheme + "://auth/failure";
 
         return new TerraProviderAuthRequest(
+                provider,
                 "en",
                 referenceId.toString(),
                 successUrl,


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
**1. 프로필 조회 및 수정(닉네임, 한줄 소개, 성별, 출생 년도) API를 구현하였습니다.**

메서드를 PATCH에서 PUT으로 변경한 이유는 

User 단일 엔티티로 봤을 때는 일부 속성을 변경하는 것이라 PATCH라는 관점이 맞지만 정말로 PATCH에 의도에 맞게 실제로 구현하기 어려움 + 이후 확장성 측면에서도 PUT이 장점이 있다고하여 PUT으로 통일하였습니다.

이후에 추가될 수정 관련된 API들도 PUT으로 통일하는 것도 제안드립니다

**2. UserResponseDto 양식**

사용자 관련 데이터는 아래와 같은 dto 형식으로 반환 될 예정입니다.
```
{
    "uuid": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
    "nickname": "ukly",
    "email": "test@test.com",
    "profileImagePath": "https://example.com/images/profile.jpg",
    "introduce": "한강 라이딩을 즐겨요!",
    "birthYear": 1990,
    "gender": "MALE"
}
```

이번에 작업한 모든 API에는 변경된 부분을 반영하여 아래의 형식대로 반환합니다.
이전 작업에서 적용했던 UUID도 이제 외부와 통신을 할때에 id의 역할로 통일하여 사용 예정이니 참고 바랍니다.
실제 DB상의 id는 DB와 소통 단계에서만 사용할 예정입니다.

## PR 포인트

## 고민과 학습내용

PUT vs PATCH 관련 궁금해서 찾아본 참고글

https://www.inflearn.com/community/questions/1175426/%EC%88%98%EC%A0%95%EC%9D%B4%EB%9D%BC%EB%8A%94-%EC%9E%91%EC%97%85%EC%9D%84-%ED%95%A0-%EB%95%8C-put%EC%9D%84-%EB%8D%94-%EC%82%AC%EC%9A%A9%ED%95%98%EB%8A%94-%EC%9D%B4%EC%9C%A0%EA%B0%80-%EC%9E%88%EC%9D%84%EA%B9%8C%EC%9A%94?srsltid=AfmBOooJ1631ja1d59uaQpzTH484xgT9uuUc7M7iHd3gu3FdeYIEWl_F

https://colabear754.tistory.com/233

## 스크린샷
