### PR TITLE
[Feat] 사용자 프로필 이미지 수정 기능 구현 및 UserResponse 변경

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/user/controller/UserApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/controller/UserApi.java
@@ -6,17 +6,22 @@ import com.ridingmate.api_server.domain.user.dto.request.BirthYearUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.GenderUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.IntroduceUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.NicknameUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.ProfileImageUpdateRequest;
 import com.ridingmate.api_server.global.exception.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "User API", description = "사용자 관련 API")
 public interface UserApi {
@@ -58,6 +63,17 @@ public interface UserApi {
     ResponseEntity<CommonResponse<UserResponse>> updateBirthYear(
             @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody BirthYearUpdateRequest request
+    );
+
+    @Operation(
+            summary = "프로필 이미지 변경", 
+            description = "현재 로그인된 사용자의 프로필 이미지를 변경합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "성공: 프로필 이미지 변경 완료")
+    @PutMapping(value = "/user/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    ResponseEntity<CommonResponse<UserResponse>> updateProfileImage(
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestPart("profileImage") MultipartFile profileImage
     );
 
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.ridingmate.api_server.domain.user.dto.request.BirthYearUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.GenderUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.IntroduceUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.NicknameUpdateRequest;
+import com.ridingmate.api_server.domain.user.dto.request.ProfileImageUpdateRequest;
 import com.ridingmate.api_server.domain.user.exception.UserSuccessCode;
 import com.ridingmate.api_server.domain.user.facade.UserFacade;
 import com.ridingmate.api_server.global.exception.CommonResponse;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -66,5 +68,14 @@ public class UserController implements UserApi {
         return ResponseEntity
                 .status(UserSuccessCode.UPDATE_BIRTH_YEAR_SUCCESS.getStatus())
                 .body(CommonResponse.success(UserSuccessCode.UPDATE_BIRTH_YEAR_SUCCESS, response));
+    }
+
+    @Override
+    @PutMapping(value = "/user/profile/image", consumes = "multipart/form-data")
+    public ResponseEntity<CommonResponse<UserResponse>> updateProfileImage(AuthUser authUser, MultipartFile profileImage) {
+        UserResponse response = userFacade.updateProfileImage(authUser.id(), profileImage);
+        return ResponseEntity
+                .status(UserSuccessCode.UPDATE_PROFILE_IMAGE_SUCCESS.getStatus())
+                .body(CommonResponse.success(UserSuccessCode.UPDATE_PROFILE_IMAGE_SUCCESS, response));
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/dto/UserResponse.java
@@ -18,7 +18,7 @@ public record UserResponse(
         String email,
 
         @Schema(description = "프로필 이미지 URL", example = "https://example.com/images/profile.jpg")
-        String profileImagePath,
+        String profileImageUrl,
 
         @Schema(description = "자기소개", example = "한강 라이딩을 즐겨요!")
         String introduce,
@@ -29,12 +29,30 @@ public record UserResponse(
         @Schema(description = "성별", example = "MALE")
         Gender gender
 ) {
+    /**
+     * User 엔티티와 프로필 이미지 URL로부터 UserResponse 생성
+     */
+    public static UserResponse of(User user, String profileImageUrl) {
+        return new UserResponse(
+                user.getUuid(),
+                user.getNickname(),
+                user.getEmail(),
+                profileImageUrl,
+                user.getIntroduce(),
+                user.getBirthYear(),
+                user.getGender()
+        );
+    }
+
+    /**
+     * User 엔티티로부터 UserResponse 생성 (path 그대로 - 하위 호환용)
+     */
     public static UserResponse from(User user) {
         return new UserResponse(
                 user.getUuid(),
                 user.getNickname(),
                 user.getEmail(),
-                user.getProfileImagePath(),
+                user.getProfileImagePath(), // path 그대로
                 user.getIntroduce(),
                 user.getBirthYear(),
                 user.getGender()

--- a/src/main/java/com/ridingmate/api_server/domain/user/dto/request/ProfileImageUpdateRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/dto/request/ProfileImageUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.ridingmate.api_server.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
+@Schema(description = "프로필 이미지 수정 요청")
+public record ProfileImageUpdateRequest(
+        @NotNull(message = "프로필 이미지 파일은 필수입니다")
+        @Schema(description = "프로필 이미지 파일", type = "string", format = "binary")
+        MultipartFile profileImage
+) {
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/entity/User.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/entity/User.java
@@ -20,6 +20,8 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeEntity {
 
+    public static final String DEFAULT_PROFILE_IMAGE_PATH = "profile/default.png";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -40,8 +42,8 @@ public class User extends BaseTimeEntity {
     @Column(name = "nickname")
     private String nickname;
 
-    @Column(name = "profile_image_path")
-    private String profileImagePath;
+    @Column(name = "profile_image_path", columnDefinition = "VARCHAR(255) DEFAULT 'profile/default.png'")
+    private String profileImagePath = DEFAULT_PROFILE_IMAGE_PATH;
 
     @Column(name = "introduce")
     private String introduce;
@@ -76,13 +78,13 @@ public class User extends BaseTimeEntity {
      * 소셜 로그인 정보로 사용자 생성
      */
     public static User createFromSocialLogin(SocialProvider provider, String socialId, 
-                                           String email, String nickname, String profileImagePath) {
+                                           String email, String nickname) {
         return User.builder()
                 .socialProvider(provider)
                 .socialId(socialId)
                 .email(email)
                 .nickname(nickname)
-                .profileImagePath(profileImagePath)
+                .profileImagePath(DEFAULT_PROFILE_IMAGE_PATH)
                 .build();
     }
 
@@ -112,6 +114,13 @@ public class User extends BaseTimeEntity {
      */
     public void updateBirthYear(Integer birthYear) {
         this.birthYear = birthYear;
+    }
+
+    /**
+     * 프로필 이미지 경로 업데이트
+     */
+    public void updateProfileImagePath(String profileImagePath) {
+        this.profileImagePath = profileImagePath;
     }
 
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/exception/UserErrorCode.java
@@ -8,7 +8,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "유저를 찾을 수 없습니다.")
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "유저를 찾을 수 없습니다."),
+    INVALID_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "INVALID_PROFILE_IMAGE", "유효하지 않은 프로필 이미지입니다."),
+    PROFILE_IMAGE_TOO_LARGE(HttpStatus.BAD_REQUEST, "PROFILE_IMAGE_TOO_LARGE", "프로필 이미지 크기가 너무 큽니다. (최대 20MB)"),
+    INVALID_PROFILE_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_PROFILE_IMAGE_FORMAT", "지원하지 않는 이미지 형식입니다. (JPG, PNG, WebP만 지원)")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/ridingmate/api_server/domain/user/exception/UserSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/exception/UserSuccessCode.java
@@ -14,7 +14,8 @@ public enum UserSuccessCode implements SuccessCode {
     UPDATE_NICKNAME_SUCCESS(HttpStatus.OK,  "닉네임 변경 성공"),
     UPDATE_INTRODUCE_SUCCESS(HttpStatus.OK, "한 줄 소개 변경 성공"),
     UPDATE_GENDER_SUCCESS(HttpStatus.OK, "성별 변경 성공"),
-    UPDATE_BIRTH_YEAR_SUCCESS(HttpStatus.OK, "출생년도 변경 성공");
+    UPDATE_BIRTH_YEAR_SUCCESS(HttpStatus.OK, "출생년도 변경 성공"),
+    UPDATE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 이미지 변경 성공");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
@@ -9,6 +9,7 @@ import com.ridingmate.api_server.domain.user.entity.User;
 import com.ridingmate.api_server.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +39,11 @@ public class UserFacade {
 
     public UserResponse updateBirthYear(Long userId, BirthYearUpdateRequest request) {
         User user = userService.updateBirthYear(userId, request);
+        return UserResponse.from(user);
+    }
+
+    public UserResponse updateProfileImage(Long userId, MultipartFile profileImage) {
+        User user = userService.updateProfileImage(userId, profileImage);
         return UserResponse.from(user);
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
@@ -7,6 +7,7 @@ import com.ridingmate.api_server.domain.user.dto.request.IntroduceUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.NicknameUpdateRequest;
 import com.ridingmate.api_server.domain.user.entity.User;
 import com.ridingmate.api_server.domain.user.service.UserService;
+import com.ridingmate.api_server.infra.aws.s3.S3Manager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,34 +17,41 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserFacade {
 
     private final UserService userService;
+    private final S3Manager s3Manager;
 
     public UserResponse getMyInfo(Long userId) {
         User user = userService.getMyInfo(userId);
-        return UserResponse.from(user);
+        String profileImageUrl = s3Manager.getPresignedUrl(user.getProfileImagePath());
+        return UserResponse.of(user, profileImageUrl);
     }
 
     public UserResponse updateNickname(Long userId, NicknameUpdateRequest request) {
         User user = userService.updateNickname(userId, request);
-        return UserResponse.from(user);
+        String profileImageUrl = s3Manager.getPresignedUrl(user.getProfileImagePath());
+        return UserResponse.of(user, profileImageUrl);
     }
 
     public UserResponse updateIntroduce(Long userId, IntroduceUpdateRequest request) {
         User user = userService.updateIntroduce(userId, request);
-        return UserResponse.from(user);
+        String profileImageUrl = s3Manager.getPresignedUrl(user.getProfileImagePath());
+        return UserResponse.of(user, profileImageUrl);
     }
 
     public UserResponse updateGender(Long userId, GenderUpdateRequest request) {
         User user = userService.updateGender(userId, request);
-        return UserResponse.from(user);
+        String profileImageUrl = s3Manager.getPresignedUrl(user.getProfileImagePath());
+        return UserResponse.of(user, profileImageUrl);
     }
 
     public UserResponse updateBirthYear(Long userId, BirthYearUpdateRequest request) {
         User user = userService.updateBirthYear(userId, request);
-        return UserResponse.from(user);
+        String profileImageUrl = s3Manager.getPresignedUrl(user.getProfileImagePath());
+        return UserResponse.of(user, profileImageUrl);
     }
 
     public UserResponse updateProfileImage(Long userId, MultipartFile profileImage) {
         User user = userService.updateProfileImage(userId, profileImage);
-        return UserResponse.from(user);
+        String profileImageUrl = s3Manager.getPresignedUrl(user.getProfileImagePath());
+        return UserResponse.of(user, profileImageUrl);
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/service/UserService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/service/UserService.java
@@ -40,8 +40,7 @@ public class UserService {
                     socialUserInfo.getProvider(),
                     socialUserInfo.getSocialId(),
                     socialUserInfo.getEmail(),
-                    socialUserInfo.getNickname(),
-                    socialUserInfo.getProfileImageUrl()
+                    socialUserInfo.getNickname()
             );
 
             User savedUser = userRepository.save(newUser);

--- a/src/main/java/com/ridingmate/api_server/domain/user/service/UserService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/service/UserService.java
@@ -9,10 +9,12 @@ import com.ridingmate.api_server.domain.user.entity.User;
 import com.ridingmate.api_server.domain.user.exception.UserErrorCode;
 import com.ridingmate.api_server.domain.user.exception.UserException;
 import com.ridingmate.api_server.domain.user.repository.UserRepository;
+import com.ridingmate.api_server.infra.aws.s3.S3Manager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final S3Manager s3Manager;
 
     /**
      * 사용자 조회 또는 생성
@@ -82,5 +85,83 @@ public class UserService {
         User user = getUser(userId);
         user.updateBirthYear(request.birthYear());
         return user;
+    }
+
+    public User updateProfileImage(Long userId, MultipartFile profileImage) {
+        User user = getUser(userId);
+        
+        // 파일 유효성 검증
+        validateProfileImage(profileImage);
+        
+        // 기존 프로필 이미지가 기본값이 아닌 경우 S3에서 삭제
+        String currentImagePath = user.getProfileImagePath();
+        if (currentImagePath != null && !currentImagePath.equals(User.DEFAULT_PROFILE_IMAGE_PATH)) {
+            try {
+                s3Manager.deleteFile(currentImagePath);
+                log.info("기존 프로필 이미지 삭제 완료: {}", currentImagePath);
+            } catch (Exception e) {
+                log.warn("기존 프로필 이미지 삭제 실패: {}", currentImagePath, e);
+            }
+        }
+        
+        // 새 프로필 이미지를 S3에 업로드
+        String imagePath = "profile/" + user.getUuid() + "_" + System.currentTimeMillis() + getFileExtension(profileImage.getOriginalFilename());
+        s3Manager.uploadFile(imagePath, profileImage);
+        
+        // 사용자 엔티티의 프로필 이미지 경로 업데이트
+        user.updateProfileImagePath(imagePath);
+        
+        log.info("사용자 {} 프로필 이미지 업데이트 완료: {}", userId, imagePath);
+        return user;
+    }
+    
+    /**
+     * 프로필 이미지 파일 유효성 검증
+     */
+    private void validateProfileImage(MultipartFile file) {
+        // 파일이 비어있는지 확인
+        if (file.isEmpty()) {
+            throw new UserException(UserErrorCode.INVALID_PROFILE_IMAGE);
+        }
+        
+        // 파일 크기 확인 (20MB 제한)
+        long maxSize = 20 * 1024 * 1024; // 20MB
+        if (file.getSize() > maxSize) {
+            throw new UserException(UserErrorCode.PROFILE_IMAGE_TOO_LARGE);
+        }
+        
+        // 파일 형식 확인 (이미지 파일만 허용)
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new UserException(UserErrorCode.INVALID_PROFILE_IMAGE_FORMAT);
+        }
+        
+        // 허용된 이미지 형식 확인
+        String[] allowedTypes = {"image/jpeg", "image/jpg", "image/png", "image/webp"};
+        boolean isAllowedType = false;
+        for (String allowedType : allowedTypes) {
+            if (allowedType.equals(contentType)) {
+                isAllowedType = true;
+                break;
+            }
+        }
+        
+        if (!isAllowedType) {
+            throw new UserException(UserErrorCode.INVALID_PROFILE_IMAGE_FORMAT);
+        }
+    }
+    
+    /**
+     * 파일 확장자 추출 (기본값: .jpg)
+     */
+    private String getFileExtension(String filename) {
+        if (filename == null || filename.isEmpty()) {
+            return ".jpg";
+        }
+        int lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            return ".jpg";
+        }
+        return filename.substring(lastDotIndex);
     }
 } 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용

1. 사용자 프로필 이미지 수정 api를 추가하였습니다. 
이미지는 Multi-part 형식으로 전송해주시면 됩니다.
이미지 업로드 크기는 20MB로 제한을 걸어두었습니다. 참고 부탁드립니다.

2. UserResponse에서 프로필 이미지를 실제 PresginedUrl을 반환하도록 변경
기존 UserResponse가 ImagePath를 반환하던 것은 큰 의미가 없다고 생각되어  PresginedUrl로 접근 가능하도록 변경하였습니다.
key값도 imageProfileUrl로 변경되었습니다 참고부탁드립니다.

```
{
  "message": "내 정보 조회 성공",
  "data": {
    "uuid": "a4b4c85b-a9d2-44c0-9643-cbce575f60aa",
    "nickname": "주욱",
    "email": "test1@example.com",
    "profileImageUrl": "https://urbanbreeze-dev.s3.ap-northeast-2.amazonaws.com/profile/a4b4c85b-a9d2-44c0-9643-cbce575f60aa_1757937406711.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20250915T120814Z&X-Amz-SignedHeaders=host&X-Amz-Credential=AKIA6LK2WHL3LIZMPO4F%2F20250915%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Expires=1800&X-Amz-Signature=2b3ad465ebe1eff6be15512a123f44f87fb2331ccb55800c84cc6dfcff13d5aa",
    "introduce": "한강에서 주로 라이딩합니다!",
    "birthYear": null,
    "gender": "MALE"
  }
}
```

## PR 포인트

## 고민과 학습내용

## 스크린샷
