### PR TITLE
[Feat] 사용자 약관 동의, 프로필 수정, 탈퇴 처리 구현

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/Activity.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/Activity.java
@@ -25,31 +25,31 @@ public class Activity extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "title", nullable = false)
+    @Column(name = "title")
     private String title;
 
-    @Column(name = "started_at", nullable = false, updatable = false)
+    @Column(name = "started_at", updatable = false)
     private LocalDateTime startedAt;
 
-    @Column(name = "ended_at", nullable = false, updatable = false)
+    @Column(name = "ended_at",updatable = false)
     private LocalDateTime endedAt;
 
     /**
      * 경로 총 거리 (단위: 미터)
      */
-    @Column(name = "distance", nullable = false)
+    @Column(name = "distance")
     private Double distance;
 
     /**
      * 총 소요 시간 (단위: 초)
      */
-    @Column(name = "duration", nullable = false)
+    @Column(name = "duration")
     private Duration duration;
 
     /**
      * 총 상승 고도 (단위: 미터)
      */
-    @Column(name = "elevation_gain", nullable = false)
+    @Column(name = "elevation_gain")
     private Double elevationGain;
 
     /**

--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/Activity.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/Activity.java
@@ -147,26 +147,25 @@ public class Activity extends BaseTimeEntity {
 
     /**
      * 활동 개인정보 마스킹 및 삭제 처리
-     * - 모든 개인정보 관련 필드 마스킹/제거
-     * - 통계용 데이터만 보존
+     * - 모든 필드를 null로 마스킹
+     * - 소프트 삭제 처리
      */
     public void maskPersonalDataForDeletion() {
-        // 1. 생체 정보 즉시 파기 (건강/민감 성격)
+        // 1. 모든 개인정보 필드 마스킹
+        this.title = null;
+        this.thumbnailImagePath = null;
         this.averageHeartRate = null;
         this.maxHeartRate = null;
-        
-        // 2. 성능 데이터 비식별 (개인 성능 특성)
         this.cadence = null;
         this.averagePower = null;
         this.maxPower = null;
-        
-        // 3. 거리/고도 데이터 비식별 (집계 또는 별도 동의)
-        this.distance = 0.0;
-        this.duration = Duration.ZERO;
-        this.elevationGain = 0.0;
-        
-        // 4. 시간 정보 제거 (별도 접근 로그 엔티티로 관리)
+        this.distance = null;
+        this.duration = null;
+        this.elevationGain = null;
         this.startedAt = null;
         this.endedAt = null;
+        
+        // 2. 소프트 삭제 처리
+        this.isDelete = true;
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/Activity.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/Activity.java
@@ -88,6 +88,12 @@ public class Activity extends BaseTimeEntity {
     @Column(name = "max_power")
     private Integer maxPower;
 
+    /**
+     * 삭제 여부 (소프트 삭제)
+     */
+    @Column(name = "is_delete", nullable = false)
+    private Boolean isDelete = false;
+
     @Builder
     private Activity(User user, String title, Double distance,
                      Duration duration, Double elevationGain,
@@ -123,5 +129,44 @@ public class Activity extends BaseTimeEntity {
      */
     public void updateTitle(String title) {
         this.title = title;
+    }
+
+    /**
+     * 소프트 삭제 처리
+     */
+    public void markAsDeleted() {
+        this.isDelete = true;
+    }
+
+    /**
+     * 삭제 여부 확인
+     */
+    public boolean isDeleted() {
+        return this.isDelete;
+    }
+
+    /**
+     * 활동 개인정보 마스킹 및 삭제 처리
+     * - 모든 개인정보 관련 필드 마스킹/제거
+     * - 통계용 데이터만 보존
+     */
+    public void maskPersonalDataForDeletion() {
+        // 1. 생체 정보 즉시 파기 (건강/민감 성격)
+        this.averageHeartRate = null;
+        this.maxHeartRate = null;
+        
+        // 2. 성능 데이터 비식별 (개인 성능 특성)
+        this.cadence = null;
+        this.averagePower = null;
+        this.maxPower = null;
+        
+        // 3. 거리/고도 데이터 비식별 (집계 또는 별도 동의)
+        this.distance = 0.0;
+        this.duration = Duration.ZERO;
+        this.elevationGain = 0.0;
+        
+        // 4. 시간 정보 제거 (별도 접근 로그 엔티티로 관리)
+        this.startedAt = null;
+        this.endedAt = null;
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityGpsLog.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityGpsLog.java
@@ -1,5 +1,8 @@
 package com.ridingmate.api_server.domain.activity.entity;
 
+import com.ridingmate.api_server.domain.activity.exception.ActivityException;
+import com.ridingmate.api_server.domain.activity.exception.code.ActivityCommonErrorCode;
+import com.ridingmate.api_server.domain.activity.exception.code.ActivityValidationErrorCode;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
@@ -26,13 +29,13 @@ public class ActivityGpsLog {
     @JoinColumn(name = "activity_id", nullable = false)
     private Activity activity;
 
-    @Column(name = "log_time", nullable = false)
+    @Column(name = "log_time")
     private LocalDateTime logTime;
 
-    @Column(name = "latitude", nullable = false)
+    @Column(name = "latitude")
     private Double latitude;
 
-    @Column(name = "longitude", nullable = false)
+    @Column(name = "longitude")
     private Double longitude;
 
     @Column(name = "elevation")
@@ -59,6 +62,11 @@ public class ActivityGpsLog {
                            Double speed, Double distance, Double heartRate, 
                            Double cadence, Double power
     ){
+
+        if (latitude == null || longitude == null || logTime == null) {
+            throw new ActivityException(ActivityValidationErrorCode.INVALID_GPS_LOG_COORDINATES);
+        }
+
         this.activity = activity;
         this.logTime = logTime;
         this.latitude = latitude;

--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityGpsLog.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityGpsLog.java
@@ -29,13 +29,13 @@ public class ActivityGpsLog {
     @JoinColumn(name = "activity_id", nullable = false)
     private Activity activity;
 
-    @Column(name = "log_time")
+    @Column(name = "log_time", nullable = false)
     private LocalDateTime logTime;
 
-    @Column(name = "latitude")
+    @Column(name = "latitude", nullable = false)
     private Double latitude;
 
-    @Column(name = "longitude")
+    @Column(name = "longitude", nullable = false)
     private Double longitude;
 
     @Column(name = "elevation")

--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityGpsLog.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityGpsLog.java
@@ -70,4 +70,30 @@ public class ActivityGpsLog {
         this.cadence = cadence;
         this.power = power;
     }
+
+    /**
+     * GPS 로그 개인정보 마스킹 처리
+     * - 좌표 데이터: 즉시 파기 (원본 위치)
+     * - 시간 정보: 즉시 파기 (동선 복원 가능)
+     * - 생체 정보: 즉시 파기 (건강/민감 성격)
+     * - 성능 데이터: 즉시 파기 (개인 성능 특성)
+     */
+    public void maskPersonalData() {
+        // 좌표 데이터 즉시 파기 (원본 위치)
+        this.latitude = null;
+        this.longitude = null;
+        this.elevation = null;
+        
+        // 시간 정보 즉시 파기 (동선 복원 가능)
+        this.logTime = null;
+        
+        // 생체 정보 즉시 파기 (건강/민감 성격)
+        this.heartRate = null;
+        
+        // 성능 데이터 즉시 파기 (개인 성능 특성)
+        this.speed = null;
+        this.distance = null;
+        this.cadence = null;
+        this.power = null;
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/exception/code/ActivityValidationErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/exception/code/ActivityValidationErrorCode.java
@@ -16,6 +16,7 @@ public enum ActivityValidationErrorCode implements ErrorCode {
     FUTURE_ACTIVITY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FUTURE_ACTIVITY_NOT_ALLOWED", "미래 시간의 활동은 생성할 수 없습니다."),
     INVALID_MONTH_PERIOD(HttpStatus.BAD_REQUEST, "INVALID_MONTH_PERIOD", "월간 통계는 정확한 월의 시작일(1일)과 마지막일을 입력해야 합니다."),
     INVALID_YEAR_PERIOD(HttpStatus.BAD_REQUEST, "INVALID_YEAR_PERIOD", "연간 통계는 정확한 연도의 시작일(1월 1일)과 마지막일(12월 31일)을 입력해야 합니다."),
+    INVALID_GPS_LOG_COORDINATES(HttpStatus.BAD_REQUEST, "INVALID_GPS_LOG_COORDINATES", "GPS 로그의 좌표와 시간은 필수입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/ridingmate/api_server/domain/activity/repository/ActivityGpsLogRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/repository/ActivityGpsLogRepository.java
@@ -70,4 +70,10 @@ public interface ActivityGpsLogRepository extends JpaRepository<ActivityGpsLog, 
      * @return GPS 로그 리스트
      */
     List<ActivityGpsLog> findByActivityIdOrderByLogTimeAsc(Long activityId);
+
+    /**
+     * 특정 활동의 모든 GPS 로그 삭제
+     * @param activityId 활동 ID
+     */
+    void deleteByActivityId(Long activityId);
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/repository/ActivityGpsLogRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/repository/ActivityGpsLogRepository.java
@@ -39,7 +39,7 @@ public interface ActivityGpsLogRepository extends JpaRepository<ActivityGpsLog, 
     @Query("""
         SELECT agl
         FROM ActivityGpsLog agl
-        WHERE agl.activity = :activity 
+        WHERE agl.activity = :activity
         ORDER BY agl.logTime ASC
         """)
     List<ActivityGpsLog> findGpsLogsByActivity(@Param("activity") Activity activity);
@@ -63,4 +63,11 @@ public interface ActivityGpsLogRepository extends JpaRepository<ActivityGpsLog, 
         ORDER BY agl.logTime ASC
         """)
     List<GpsLogProjection> findGpsLogProjectionsByActivity(@Param("activity") Activity activity);
+
+    /**
+     * 특정 활동의 모든 GPS 로그를 timestamp 순으로 조회 (Activity ID로)
+     * @param activityId 활동 ID
+     * @return GPS 로그 리스트
+     */
+    List<ActivityGpsLog> findByActivityIdOrderByLogTimeAsc(Long activityId);
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/repository/ActivityImageRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/repository/ActivityImageRepository.java
@@ -72,4 +72,10 @@ public interface ActivityImageRepository extends JpaRepository<ActivityImage, Lo
            "WHERE ai.activity.id IN :activityIds " +
            "GROUP BY ai.activity.id")
     List<Object[]> countByActivityIds(@Param("activityIds") List<Long> activityIds);
+
+    /**
+     * 특정 활동의 모든 이미지 삭제
+     * @param activityId 활동 ID
+     */
+    void deleteByActivityId(Long activityId);
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/service/ActivityService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/service/ActivityService.java
@@ -518,4 +518,146 @@ public class ActivityService {
         return DeleteActivityImageResponse.from(imageId);
     }
 
+    /**
+     * 사용자 삭제 시 활동 데이터 처리
+     * - 활동 데이터는 법정 기간 동안 보존 (삭제하지 않음)
+     * - 사용자 정보만 마스킹 처리
+     */
+    @Transactional
+    public void handleUserDeletion(User user) {
+        log.info("활동 데이터 처리 시작: userId={}", user.getId());
+        
+        try {
+            // 1. 사용자의 모든 활동 조회 (삭제된 활동 포함)
+            List<Activity> userActivities = activityRepository.findByUser(user);
+            
+            // 2. 활동 정보 마스킹 처리
+            maskActivityUserInfo(userActivities);
+            
+            // 3. 활동 이미지 처리 (S3에서 삭제)
+            handleActivityImages(userActivities);
+            
+            // 4. 활동 GPS 로그 처리 (개인정보 즉시 파기)
+            handleActivityGpsLogs(userActivities);
+            
+            log.info("활동 데이터 처리 완료: userId={}, count={}", user.getId(), userActivities.size());
+        } catch (Exception e) {
+            log.error("활동 데이터 처리 중 오류 발생: userId={}", user.getId(), e);
+            // 활동 데이터 처리 실패해도 사용자 삭제는 계속 진행
+        }
+    }
+
+    /**
+     * 활동 정보 마스킹 및 소프트 삭제 처리
+     * - 모든 개인정보 관련 필드 마스킹/제거
+     * - 통계용 데이터만 보존
+     */
+    private void maskActivityUserInfo(List<Activity> activities) {
+        log.info("활동 정보 마스킹 및 소프트 삭제 처리 시작: count={}", activities.size());
+        
+        for (Activity activity : activities) {
+            // 1. 활동 제목 마스킹 (개인정보 보호)
+            String maskedTitle = "탈퇴한 사용자의 활동";
+            activity.updateTitle(maskedTitle);
+            
+            // 2. 썸네일 이미지 경로를 null로 설정 (ActivityImage 삭제 후 처리)
+            activity.updateThumbnailImagePath(null);
+            
+            // 3. 개인정보 마스킹 및 삭제 처리 (통합)
+            activity.maskPersonalDataForDeletion();
+            
+            // 4. 소프트 삭제 처리
+            activity.markAsDeleted();
+            
+            log.debug("활동 정보 마스킹 및 소프트 삭제: activityId={}, title={}", 
+                activity.getId(), maskedTitle);
+        }
+        
+        log.info("활동 정보 마스킹 및 소프트 삭제 처리 완료: count={}", activities.size());
+    }
+
+    /**
+     * 활동 이미지 처리 (S3에서 삭제)
+     * - ActivityImage 테이블의 모든 이미지를 삭제 (썸네일 포함)
+     */
+    private void handleActivityImages(List<Activity> activities) {
+        log.info("활동 이미지 처리 시작: count={}", activities.size());
+        
+        for (Activity activity : activities) {
+            try {
+                // ActivityImage 테이블의 모든 이미지 조회 및 삭제
+                deleteAllActivityImages(activity);
+                
+            } catch (Exception e) {
+                log.warn("활동 이미지 처리 중 오류: activityId={}", activity.getId(), e);
+            }
+        }
+        
+        log.info("활동 이미지 처리 완료: count={}", activities.size());
+    }
+
+    /**
+     * 활동의 모든 이미지 삭제 (썸네일 포함)
+     */
+    private void deleteAllActivityImages(Activity activity) {
+        try {
+            // 활동의 모든 이미지 조회 (썸네일 포함)
+            List<ActivityImage> activityImages = activityImageRepository.findByActivityIdOrderByDisplayOrder(activity.getId());
+            
+            log.debug("활동 이미지 삭제 시작: activityId={}, count={}", activity.getId(), activityImages.size());
+            
+            for (ActivityImage activityImage : activityImages) {
+                try {
+                    // S3에서 이미지 삭제 (썸네일 포함 모든 이미지)
+                    s3Manager.deleteFile(activityImage.getImagePath());
+                    log.debug("활동 이미지 삭제: activityId={}, imageId={}, path={}", 
+                        activity.getId(), activityImage.getId(), activityImage.getImagePath());
+                } catch (Exception e) {
+                    log.warn("활동 이미지 삭제 실패: activityId={}, imageId={}, path={}", 
+                        activity.getId(), activityImage.getId(), activityImage.getImagePath(), e);
+                }
+            }
+            
+            // DB에서 모든 이미지 삭제 (썸네일 포함)
+            activityImageRepository.deleteByActivityId(activity.getId());
+            
+            log.debug("활동 이미지 DB 삭제 완료: activityId={}", activity.getId());
+            
+        } catch (Exception e) {
+            log.warn("활동 이미지 삭제 중 오류: activityId={}", activity.getId(), e);
+        }
+    }
+
+    /**
+     * 활동 GPS 로그 처리 (개인정보 즉시 파기)
+     * - 좌표 데이터: 즉시 파기 (원본 위치)
+     * - 시간 정보: 즉시 파기 (동선 복원 가능)
+     * - 생체 정보: 즉시 파기 (건강/민감 성격)
+     * - 성능 데이터: 즉시 파기 (개인 성능 특성)
+     */
+    private void handleActivityGpsLogs(List<Activity> activities) {
+        log.info("활동 GPS 로그 처리 시작: count={}", activities.size());
+        
+        for (Activity activity : activities) {
+            try {
+                // 활동의 모든 GPS 로그 조회
+                List<ActivityGpsLog> activityGpsLogs = activityGpsLogRepository.findByActivityIdOrderByLogTimeAsc(activity.getId());
+                
+                log.debug("활동 GPS 로그 삭제 시작: activityId={}, count={}", activity.getId(), activityGpsLogs.size());
+                
+                for (ActivityGpsLog activityGpsLog : activityGpsLogs) {
+                    // GPS 로그의 개인정보 마스킹 (좌표, 시간, 생체, 성능 데이터)
+                    activityGpsLog.maskPersonalData();
+                }
+                
+                log.debug("활동 GPS 로그 마스킹 완료: activityId={}", activity.getId());
+                
+            } catch (Exception e) {
+                log.warn("활동 GPS 로그 처리 중 오류: activityId={}", activity.getId(), e);
+            }
+        }
+        
+        log.info("활동 GPS 로그 처리 완료: count={}", activities.size());
+    }
+
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/service/ActivityService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/service/ActivityService.java
@@ -556,21 +556,10 @@ public class ActivityService {
         log.info("활동 정보 마스킹 및 소프트 삭제 처리 시작: count={}", activities.size());
         
         for (Activity activity : activities) {
-            // 1. 활동 제목 마스킹 (개인정보 보호)
-            String maskedTitle = "탈퇴한 사용자의 활동";
-            activity.updateTitle(maskedTitle);
-            
-            // 2. 썸네일 이미지 경로를 null로 설정 (ActivityImage 삭제 후 처리)
-            activity.updateThumbnailImagePath(null);
-            
-            // 3. 개인정보 마스킹 및 삭제 처리 (통합)
+            // 모든 개인정보 필드 마스킹 및 소프트 삭제 처리 (통합)
             activity.maskPersonalDataForDeletion();
             
-            // 4. 소프트 삭제 처리
-            activity.markAsDeleted();
-            
-            log.debug("활동 정보 마스킹 및 소프트 삭제: activityId={}, title={}", 
-                activity.getId(), maskedTitle);
+            log.debug("활동 정보 마스킹 및 소프트 삭제: activityId={}", activity.getId());
         }
         
         log.info("활동 정보 마스킹 및 소프트 삭제 처리 완료: count={}", activities.size());
@@ -645,12 +634,10 @@ public class ActivityService {
                 
                 log.debug("활동 GPS 로그 삭제 시작: activityId={}, count={}", activity.getId(), activityGpsLogs.size());
                 
-                for (ActivityGpsLog activityGpsLog : activityGpsLogs) {
-                    // GPS 로그의 개인정보 마스킹 (좌표, 시간, 생체, 성능 데이터)
-                    activityGpsLog.maskPersonalData();
-                }
+                // DB에서 모든 GPS 로그 하드 삭제
+                activityGpsLogRepository.deleteByActivityId(activity.getId());
                 
-                log.debug("활동 GPS 로그 마스킹 완료: activityId={}", activity.getId());
+                log.debug("활동 GPS 로그 하드 삭제 완료: activityId={}", activity.getId());
                 
             } catch (Exception e) {
                 log.warn("활동 GPS 로그 처리 중 오류: activityId={}", activity.getId(), e);

--- a/src/main/java/com/ridingmate/api_server/domain/auth/dto/AgreementStatusResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/auth/dto/AgreementStatusResponse.java
@@ -1,0 +1,33 @@
+package com.ridingmate.api_server.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 사용자 동의항목 상태 응답 DTO
+ */
+public record AgreementStatusResponse(
+        @Schema(description = "서비스 이용약관 동의 여부", example = "true")
+        Boolean termsOfServiceAgreed,
+        
+        @Schema(description = "개인정보 처리방침 동의 여부", example = "true")
+        Boolean privacyPolicyAgreed,
+        
+        @Schema(description = "위치기반 서비스 이용약관 동의 여부", example = "false")
+        Boolean locationServiceAgreed,
+        
+        @Schema(description = "모든 필수 동의항목 동의 여부", example = "false")
+        Boolean isCompleted
+) {
+    public static AgreementStatusResponse from(Boolean termsOfServiceAgreed, 
+                                            Boolean privacyPolicyAgreed, 
+                                            Boolean locationServiceAgreed) {
+        boolean allRequired = termsOfServiceAgreed && privacyPolicyAgreed && locationServiceAgreed;
+        
+        return new AgreementStatusResponse(
+                termsOfServiceAgreed,
+                privacyPolicyAgreed,
+                locationServiceAgreed,
+                allRequired
+        );
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/auth/dto/AgreementUpdateRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/auth/dto/AgreementUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.ridingmate.api_server.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 사용자 동의항목 업데이트 요청 DTO
+ */
+public record AgreementUpdateRequest(
+        @NotNull(message = "서비스 이용약관 동의 여부는 필수입니다")
+        @Schema(description = "서비스 이용약관 동의 여부", example = "true")
+        Boolean termsOfServiceAgreed,
+        
+        @NotNull(message = "개인정보 처리방침 동의 여부는 필수입니다")
+        @Schema(description = "개인정보 처리방침 동의 여부", example = "true")
+        Boolean privacyPolicyAgreed,
+        
+        @NotNull(message = "위치기반 서비스 이용약관 동의 여부는 필수입니다")
+        @Schema(description = "위치기반 서비스 이용약관 동의 여부", example = "true")
+        Boolean locationServiceAgreed
+) {
+}

--- a/src/main/java/com/ridingmate/api_server/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/auth/dto/response/LoginResponse.java
@@ -1,6 +1,7 @@
 package com.ridingmate.api_server.domain.auth.dto.response;
 
 import com.ridingmate.api_server.domain.auth.dto.TokenInfo;
+import com.ridingmate.api_server.domain.auth.dto.AgreementStatusResponse;
 import com.ridingmate.api_server.domain.user.entity.User;
 import com.ridingmate.api_server.domain.user.enums.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -15,7 +16,10 @@ public record LoginResponse(
         TokenInfo tokenInfo,
 
         @Schema(description = "사용자 정보")
-        UserInfo userInfo
+        UserInfo userInfo,
+        
+        @Schema(description = "동의항목 상태")
+        AgreementStatusResponse agreementStatus
 ) {
 
     /**
@@ -49,10 +53,11 @@ public record LoginResponse(
      *
      * @param tokenInfo JWT 토큰 정보
      * @param userInfo 사용자 정보
+     * @param agreementStatus 동의항목 상태
      * @return LoginResponse
      */
-    public static LoginResponse of(TokenInfo tokenInfo, UserInfo userInfo) {
-        return new LoginResponse(tokenInfo, userInfo);
+    public static LoginResponse of(TokenInfo tokenInfo, UserInfo userInfo, AgreementStatusResponse agreementStatus) {
+        return new LoginResponse(tokenInfo, userInfo, agreementStatus);
     }
 
     /**
@@ -60,9 +65,10 @@ public record LoginResponse(
      *
      * @param tokenInfo JWT 토큰 정보
      * @param user 사용자
+     * @param agreementStatus 동의항목 상태
      * @return LoginResponse
      */
-    public static LoginResponse of(TokenInfo tokenInfo, User user) {
+    public static LoginResponse of(TokenInfo tokenInfo, User user, AgreementStatusResponse agreementStatus) {
         UserInfo userInfo = new UserInfo(
                 user.getUuid(),
                 user.getNickname(),
@@ -72,6 +78,6 @@ public record LoginResponse(
                 user.getBirthYear(),
                 user.getGender()
         );
-        return LoginResponse.of(tokenInfo, userInfo);
+        return LoginResponse.of(tokenInfo, userInfo, agreementStatus);
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/auth/facade/AuthFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/auth/facade/AuthFacade.java
@@ -4,6 +4,7 @@ import com.ridingmate.api_server.domain.auth.dto.request.AppleLoginRequest;
 import com.ridingmate.api_server.domain.auth.dto.request.GoogleLoginRequest;
 import com.ridingmate.api_server.domain.auth.dto.request.KakaoLoginRequest;
 import com.ridingmate.api_server.domain.auth.dto.response.LoginResponse;
+import com.ridingmate.api_server.domain.auth.service.AgreementService;
 import com.ridingmate.api_server.domain.auth.service.RefreshTokenService;
 import com.ridingmate.api_server.domain.auth.service.TokenService;
 import com.ridingmate.api_server.domain.user.entity.User;
@@ -12,6 +13,7 @@ import com.ridingmate.api_server.domain.auth.dto.AppleUserInfo;
 import com.ridingmate.api_server.domain.auth.dto.GoogleUserInfo;
 import com.ridingmate.api_server.domain.auth.dto.KakaoUserInfo;
 import com.ridingmate.api_server.domain.auth.dto.TokenInfo;
+import com.ridingmate.api_server.domain.auth.dto.AgreementStatusResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -24,6 +26,7 @@ public class AuthFacade {
     private final TokenService tokenService;
     private final UserService userService;
     private final RefreshTokenService refreshTokenService;
+    private final AgreementService agreementService;
 
     /**
      * Google 로그인 처리
@@ -38,11 +41,14 @@ public class AuthFacade {
         // 2. 사용자 조회 또는 생성
         User user = userService.findOrCreateUser(googleUserInfo);
         
-        // 3. JWT 토큰 생성
+        // 3. 동의항목 상태 조회
+        AgreementStatusResponse agreementStatus = agreementService.getAgreementStatus(user);
+        
+        // 4. JWT 토큰 생성
         TokenInfo tokenInfo = tokenService.generateToken(user);
         
-        // 4. 응답 생성
-        return LoginResponse.of(tokenInfo, user);
+        // 5. 응답 생성
+        return LoginResponse.of(tokenInfo, user, agreementStatus);
     }
 
     /**
@@ -52,14 +58,20 @@ public class AuthFacade {
      * @return LoginResponse 로그인 응답
      */
     public LoginResponse appleLogin(AppleLoginRequest request) {
-
+        // 1. Apple ID 토큰 검증
         AppleUserInfo appleUserInfo = tokenService.verifyAppleToken(request.idToken());
 
+        // 2. 사용자 조회 또는 생성
         User user = userService.findOrCreateUser(appleUserInfo);
 
+        // 3. 동의항목 상태 조회
+        AgreementStatusResponse agreementStatus = agreementService.getAgreementStatus(user);
+
+        // 4. JWT 토큰 생성
         TokenInfo tokenInfo = tokenService.generateToken(user);
 
-        return LoginResponse.of(tokenInfo, user);
+        // 5. 응답 생성
+        return LoginResponse.of(tokenInfo, user, agreementStatus);
     }
 
     /**
@@ -75,12 +87,14 @@ public class AuthFacade {
         // 2. 사용자 조회 또는 생성
         User user = userService.findOrCreateUser(kakaoUserInfo);
         
-        // 3. JWT 토큰 생성
+        // 3. 동의항목 상태 조회
+        AgreementStatusResponse agreementStatus = agreementService.getAgreementStatus(user);
+        
+        // 4. JWT 토큰 생성
         TokenInfo tokenInfo = tokenService.generateToken(user);
         
-        // 4. 응답 생성
-        return LoginResponse.of(tokenInfo, user
-        );
+        // 5. 응답 생성
+        return LoginResponse.of(tokenInfo, user, agreementStatus);
     }
 
     public TokenInfo refreshAccessToken(String refreshToken){

--- a/src/main/java/com/ridingmate/api_server/domain/auth/service/AgreementService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/auth/service/AgreementService.java
@@ -1,0 +1,92 @@
+package com.ridingmate.api_server.domain.auth.service;
+
+import com.ridingmate.api_server.domain.auth.dto.AgreementStatusResponse;
+import com.ridingmate.api_server.domain.auth.dto.AgreementUpdateRequest;
+import com.ridingmate.api_server.domain.user.entity.User;
+import com.ridingmate.api_server.domain.user.exception.UserErrorCode;
+import com.ridingmate.api_server.domain.user.exception.UserException;
+import com.ridingmate.api_server.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 사용자 동의항목 관리 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AgreementService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자의 동의항목 상태 조회
+     *
+     * @param user 사용자
+     * @return 동의항목 상태 응답
+     */
+    @Transactional(readOnly = true)
+    public AgreementStatusResponse getAgreementStatus(User user) {
+        return AgreementStatusResponse.from(
+                user.getTermsOfServiceAgreed(),
+                user.getPrivacyPolicyAgreed(),
+                user.getLocationServiceAgreed()
+        );
+    }
+
+    /**
+     * 사용자의 동의항목 업데이트
+     *
+     * @param userId 사용자 ID
+     * @param request 동의항목 업데이트 요청
+     * @return 업데이트된 동의항목 상태 응답
+     */
+    @Transactional
+    public AgreementStatusResponse updateAgreements(Long userId, AgreementUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userId));
+
+        // 동의항목 업데이트
+        user.updateTermsOfServiceAgreed(request.termsOfServiceAgreed());
+        user.updatePrivacyPolicyAgreed(request.privacyPolicyAgreed());
+        user.updateLocationServiceAgreed(request.locationServiceAgreed());
+
+        log.info("사용자 {}의 동의항목이 업데이트되었습니다 - 서비스약관: {}, 개인정보: {}, 위치서비스: {}", 
+                userId, request.termsOfServiceAgreed(), request.privacyPolicyAgreed(), request.locationServiceAgreed());
+
+        return AgreementStatusResponse.from(
+                user.getTermsOfServiceAgreed(),
+                user.getPrivacyPolicyAgreed(),
+                user.getLocationServiceAgreed()
+        );
+    }
+
+    /**
+     * 사용자의 필수 동의항목 완료 여부 확인
+     *
+     * @param userId 사용자 ID
+     * @return 모든 필수 동의항목 동의 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean isAllRequiredAgreementsCompleted(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userId));
+
+        return user.getTermsOfServiceAgreed() && 
+               user.getPrivacyPolicyAgreed() && 
+               user.getLocationServiceAgreed();
+    }
+
+    /**
+     * 사용자의 동의항목 상태를 체크하고 필요한 동의항목이 있는지 확인
+     *
+     * @param userId 사용자 ID
+     * @return 동의가 필요한 항목이 있으면 true, 모든 동의가 완료되었으면 false
+     */
+    @Transactional(readOnly = true)
+    public boolean hasRequiredAgreementsPending(Long userId) {
+        return !isAllRequiredAgreementsCompleted(userId);
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
@@ -32,7 +32,7 @@ public class Route extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "title", nullable = false)
+    @Column(name = "title")
     private String title;
 
     @Column(name = "description")
@@ -41,22 +41,22 @@ public class Route extends BaseTimeEntity {
     /**
      * 경로 총 거리 (단위: 미터)
      */
-    @Column(name = "distance", nullable = false)
+    @Column(name = "distance")
     private Double distance;
 
     /**
      * 총 소요 시간 (단위: 초)
      */
-    @Column(name = "duration", nullable = false)
+    @Column(name = "duration")
     private Duration duration;
 
     /**
      * 총 상승 고도 (단위: 미터)
      */
-    @Column(name = "elevation_gain", nullable = false)
+    @Column(name = "elevation_gain")
     private Double elevationGain;
 
-    @Column(name = "route_id", nullable = false, unique = true)
+    @Column(name = "route_id", unique = true)
     private UUID routeId;
 
     @Enumerated(EnumType.STRING)
@@ -77,19 +77,19 @@ public class Route extends BaseTimeEntity {
     @Column(name = "gpx_file_path")
     private String gpxFilePath;
 
-    @Column(name = "max_lat", nullable = false)
+    @Column(name = "max_lat")
     private Double maxLat;
 
-    @Column(name = "max_lon", nullable = false)
+    @Column(name = "max_lon")
     private Double maxLon;
 
-    @Column(name = "min_lat", nullable = false)
+    @Column(name = "min_lat")
     private Double minLat;
 
-    @Column(name = "min_lon", nullable = false)
+    @Column(name = "min_lon")
     private Double minLon;
 
-    @Column(name = "route_line", nullable = false, columnDefinition = "geometry(LineString, 4326)")
+    @Column(name = "route_line", columnDefinition = "geometry(LineString, 4326)")
     private LineString routeLine;
 
     @OneToOne(mappedBy = "route", cascade = CascadeType.ALL)

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
@@ -162,4 +162,18 @@ public class Route extends BaseTimeEntity {
     public List<Coordinate> getAllCoordinates() {
         return GeometryUtil.getAllCoordinates(this.routeLine);
     }
+
+    /**
+     * 경로 제목 업데이트
+     */
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    /**
+     * 경로 설명 업데이트
+     */
+    public void updateDescription(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
@@ -182,32 +182,26 @@ public class Route extends BaseTimeEntity {
 
     /**
      * 경로 개인정보 마스킹 및 삭제 처리
-     * - 모든 개인정보 관련 필드 마스킹/제거
+     * - 모든 필드를 null로 마스킹
+     * - 소프트 삭제 처리
      */
     public void maskPersonalDataForDeletion() {
-        // 1. 제목 마스킹 (개인정보 보호)
-        this.title = "탈퇴한 사용자의 경로";
-        
-        // 2. 설명 제거 (개인정보 보호)
+        // 1. 모든 개인정보 필드 마스킹
+        this.title = null;
         this.description = null;
-        
-        // 3. 썸네일 이미지 경로 제거 (개인정보 보호)
         this.thumbnailImagePath = null;
-        
-        // 4. GPX 파일 경로 제거 (개인정보 보호)
         this.gpxFilePath = null;
-        
-        // 5. 거리/시간/고도 데이터 마스킹 (개인정보 보호)
-        this.distance = 0.0;
-        this.duration = Duration.ZERO;
-        this.elevationGain = 0.0;
-        
-        // 6. 좌표 정보 마스킹 (개인정보 보호)
+        this.distance = null;
+        this.duration = null;
+        this.elevationGain = null;
         this.maxLat = null;
         this.maxLon = null;
         this.minLat = null;
         this.minLon = null;
         this.routeLine = null;
+        
+        // 2. 소프트 삭제 처리
+        this.isDelete = true;
     }
 
     /**

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
@@ -95,6 +95,9 @@ public class Route extends BaseTimeEntity {
     @OneToOne(mappedBy = "route", cascade = CascadeType.ALL)
     private Recommendation recommendation;
 
+    @Column(name = "is_delete", nullable = false)
+    private Boolean isDelete = false;
+
 
     @Builder
     private Route(User user, String title, String description, Double distance, Duration duration, Double elevationGain,
@@ -205,5 +208,19 @@ public class Route extends BaseTimeEntity {
         this.minLat = null;
         this.minLon = null;
         this.routeLine = null;
+    }
+
+    /**
+     * 경로 소프트 삭제 처리
+     */
+    public void markAsDeleted() {
+        this.isDelete = true;
+    }
+
+    /**
+     * 경로 삭제 여부 확인
+     */
+    public boolean isDeleted() {
+        return this.isDelete;
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
@@ -176,4 +176,34 @@ public class Route extends BaseTimeEntity {
     public void updateDescription(String description) {
         this.description = description;
     }
+
+    /**
+     * 경로 개인정보 마스킹 및 삭제 처리
+     * - 모든 개인정보 관련 필드 마스킹/제거
+     */
+    public void maskPersonalDataForDeletion() {
+        // 1. 제목 마스킹 (개인정보 보호)
+        this.title = "탈퇴한 사용자의 경로";
+        
+        // 2. 설명 제거 (개인정보 보호)
+        this.description = null;
+        
+        // 3. 썸네일 이미지 경로 제거 (개인정보 보호)
+        this.thumbnailImagePath = null;
+        
+        // 4. GPX 파일 경로 제거 (개인정보 보호)
+        this.gpxFilePath = null;
+        
+        // 5. 거리/시간/고도 데이터 마스킹 (개인정보 보호)
+        this.distance = 0.0;
+        this.duration = Duration.ZERO;
+        this.elevationGain = 0.0;
+        
+        // 6. 좌표 정보 마스킹 (개인정보 보호)
+        this.maxLat = null;
+        this.maxLon = null;
+        this.minLat = null;
+        this.minLon = null;
+        this.routeLine = null;
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGpsLog.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGpsLog.java
@@ -44,4 +44,25 @@ public class RouteGpsLog {
         this.elevation = elevation;
         this.logTime = logTime;
     }
+
+    /**
+     * 경로 GPS 로그 개인정보 마스킹 처리
+     * - GPS 데이터는 법정 보존 대상이지만 개인정보는 마스킹
+     * - 좌표, 고도, 시간 정보는 개인정보로 간주하여 마스킹
+     */
+    public void maskPersonalDataForDeletion() {
+        // 1. 좌표 정보 마스킹 (개인 위치 정보)
+        this.latitude = null;
+        this.longitude = null;
+        
+        // 2. 고도 정보 마스킹 (개인 위치 정보)
+        this.elevation = null;
+        
+        // 3. 시간 정보 마스킹 (개인 활동 패턴)
+        this.logTime = null;
+        
+        // GPS 데이터는 법정 보존 대상이지만 개인정보 보호를 위해 마스킹
+        // - 통계용 집계 데이터는 별도 테이블에서 관리
+        // - 개별 GPS 로그는 개인정보로 간주하여 마스킹
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGpsLog.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGpsLog.java
@@ -26,13 +26,13 @@ public class RouteGpsLog {
     @JoinColumn(name = "route_id", nullable = false)
     private Route route;
 
-    @Column(name = "log_time")
+    @Column(name = "log_time", nullable = false)
     private LocalDateTime logTime;
 
-    @Column(name = "longitude")
+    @Column(name = "longitude", nullable = false)
     private Double longitude;
 
-    @Column(name = "latitude")
+    @Column(name = "latitude", nullable = false)
     private Double latitude;
 
     @Column(name = "elevation")

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGpsLog.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGpsLog.java
@@ -1,5 +1,7 @@
 package com.ridingmate.api_server.domain.route.entity;
 
+import com.ridingmate.api_server.domain.route.exception.RouteException;
+import com.ridingmate.api_server.domain.route.exception.code.RouteCreationErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,13 +26,13 @@ public class RouteGpsLog {
     @JoinColumn(name = "route_id", nullable = false)
     private Route route;
 
-    @Column(name = "log_time", nullable = false)
+    @Column(name = "log_time")
     private LocalDateTime logTime;
 
-    @Column(name = "longitude", nullable = false)
+    @Column(name = "longitude")
     private Double longitude;
 
-    @Column(name = "latitude", nullable = false)
+    @Column(name = "latitude")
     private Double latitude;
 
     @Column(name = "elevation")
@@ -38,6 +40,11 @@ public class RouteGpsLog {
 
     @Builder
     private RouteGpsLog(Route route, Double longitude, Double latitude, Double elevation, LocalDateTime logTime){
+        // GPS 로그 필수 값 검증
+        if (latitude == null || longitude == null || logTime == null) {
+            throw new RouteException(RouteCreationErrorCode.INVALID_GPS_LOG_COORDINATES);
+        }
+        
         this.route = route;
         this.longitude = longitude;
         this.latitude = latitude;

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/code/RouteCreationErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/code/RouteCreationErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum RouteCreationErrorCode implements ErrorCode {
     ROUTE_POLYLINE_INVALID(HttpStatus.BAD_REQUEST, "ROUTE_POLYLINE_INVALID", "Polyline 형식이 올바르지 않습니다."),
     ROUTE_NOT_ENOUGH_POINTS(HttpStatus.BAD_REQUEST, " ROUTE_NOT_ENOUGH_POINTS", "경로를 생성하려면 최소 2개 이상의 지점이 필요합니다."),
+    INVALID_GPS_LOG_COORDINATES(HttpStatus.BAD_REQUEST, "INVALID_GPS_LOG_COORDINATES", "GPS 로그의 좌표와 시간은 필수입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteGpsLogRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteGpsLogRepository.java
@@ -9,4 +9,10 @@ import java.util.List;
 @Repository
 public interface RouteGpsLogRepository extends JpaRepository<RouteGpsLog, Long> {
     List<RouteGpsLog> findByRouteIdOrderByLogTimeAsc(Long routeId);
+    
+    /**
+     * 특정 경로의 모든 GPS 로그 삭제
+     * @param routeId 경로 ID
+     */
+    void deleteByRouteId(Long routeId);
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteRepository.java
@@ -162,4 +162,9 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
             """)
         RouteFilterRangeProjection findMaxDistanceAndElevationForRecommendations();
 
+    /**
+     * 특정 사용자가 생성한 모든 경로 조회
+     */
+    List<Route> findByUser(User user);
+
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteRepository.java
@@ -26,6 +26,7 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
         FROM Route r
         JOIN FETCH r.user
         WHERE r.id = :routeId
+        AND r.isDelete = false
         """)
     Optional<Route> findRouteWithUser(@Param("routeId") Long routeId);
 
@@ -34,6 +35,7 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
         FROM Route r
         JOIN FETCH r.user
         WHERE r.routeId = :routeId
+        AND r.isDelete = false
         """)
     Optional<Route> findRouteWithUserByRouteId(@Param("routeId") UUID routeId);
 
@@ -41,6 +43,7 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
         SELECT r
         FROM Route r
         WHERE r.routeId = :routeId
+        AND r.isDelete = false
         """)
     Optional<Route> findByRouteId(@Param("routeId") UUID routeId);
 
@@ -53,6 +56,7 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
         WHERE ur.user = :user
         AND ur.relationType = :relationType
         AND ur.isDelete = false
+        AND r.isDelete = false
         AND (:minDistance IS NULL OR r.distance >= :minDistance)
         AND (:maxDistance IS NULL OR r.distance <= :maxDistance)
         AND (:minElevationGain IS NULL OR r.elevationGain >= :minElevationGain)
@@ -75,6 +79,7 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
         WHERE ur.user = :user
         AND ur.relationType IN :relationTypes
         AND ur.isDelete = false
+        AND r.isDelete = false
         AND (:minDistance IS NULL OR r.distance >= :minDistance)
         AND (:maxDistance IS NULL OR r.distance <= :maxDistance)
         AND (:minElevationGain IS NULL OR r.elevationGain >= :minElevationGain)
@@ -96,6 +101,7 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
         JOIN UserRoute ur ON ur.route = r
         WHERE ur.user = :user
         AND ur.isDelete = false
+        AND r.isDelete = false
         AND (:minDistance IS NULL OR r.distance >= :minDistance)
         AND (:maxDistance IS NULL OR r.distance <= :maxDistance)
         AND (:minElevationGain IS NULL OR r.elevationGain >= :minElevationGain)
@@ -114,7 +120,8 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
     @Query("""
         SELECT r FROM Route r
         JOIN r.recommendation rec
-        WHERE (:recommendationTypes IS NULL OR rec.recommendationType IN :recommendationTypes)
+        WHERE r.isDelete = false
+        AND (:recommendationTypes IS NULL OR rec.recommendationType IN :recommendationTypes)
         AND (:regions IS NULL OR r.region IN :regions)
         AND (:difficulties IS NULL OR r.difficulty IN :difficulties)
         AND (:minDistance IS NULL OR r.distance >= :minDistance)
@@ -145,6 +152,7 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
             JOIN UserRoute ur ON ur.route = r
             WHERE ur.user = :user
             AND ur.isDelete = false
+            AND r.isDelete = false
             """)
         RouteFilterRangeProjection findMaxDistanceAndElevationByUser(@Param("user") User user);
 
@@ -159,6 +167,7 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
                 MAX(r.elevationGain) as maxElevationGain
             FROM Route r
             JOIN r.recommendation rec
+            WHERE r.isDelete = false
             """)
         RouteFilterRangeProjection findMaxDistanceAndElevationForRecommendations();
 

--- a/src/main/java/com/ridingmate/api_server/domain/route/repository/UserRouteRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/repository/UserRouteRepository.java
@@ -7,6 +7,7 @@ import com.ridingmate.api_server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -16,4 +17,9 @@ public interface UserRouteRepository extends JpaRepository<UserRoute, Long> {
      * 특정 사용자와 경로 간의 특정 관계 타입 조회 (활성 관계만)
      */
     Optional<UserRoute> findByUserAndRouteAndRelationTypeAndIsDeleteFalse(User user, Route route, RouteRelationType relationType);
+
+    /**
+     * 특정 사용자의 모든 활성 경로 관계 조회
+     */
+    List<UserRoute> findByUserAndIsDeleteFalse(User user);
 } 

--- a/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
@@ -467,14 +467,10 @@ public class RouteService {
         List<Route> userRoutes = routeRepository.findByUser(user);
         
         for (Route route : userRoutes) {
-            // 경로 개인정보 마스킹 및 삭제 처리 (통합)
+            // 모든 개인정보 필드 마스킹 및 소프트 삭제 처리 (통합)
             route.maskPersonalDataForDeletion();
             
-            // 경로 소프트 삭제 처리
-            route.markAsDeleted();
-            
-            log.debug("경로 사용자 정보 마스킹 및 소프트 삭제: routeId={}, title={}", 
-                route.getId(), route.getTitle());
+            log.debug("경로 사용자 정보 마스킹 및 소프트 삭제: routeId={}", route.getId());
         }
         
         log.info("경로 사용자 정보 마스킹 처리 완료: userId={}, count={}", 
@@ -499,12 +495,10 @@ public class RouteService {
                 log.debug("경로 GPS 로그 마스킹 시작: routeId={}, count={}", 
                     route.getId(), routeGpsLogs.size());
                 
-                for (RouteGpsLog routeGpsLog : routeGpsLogs) {
-                    // GPS 로그의 개인정보 마스킹 처리
-                    routeGpsLog.maskPersonalDataForDeletion();
-                }
+                // DB에서 모든 GPS 로그 하드 삭제
+                routeGpsLogRepository.deleteByRouteId(route.getId());
                 
-                log.debug("경로 GPS 로그 마스킹 완료: routeId={}", route.getId());
+                log.debug("경로 GPS 로그 하드 삭제 완료: routeId={}", route.getId());
             }
             
             log.info("경로 GPS 로그 처리 완료: userId={}, routeCount={}", 

--- a/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
@@ -470,7 +470,10 @@ public class RouteService {
             // 경로 개인정보 마스킹 및 삭제 처리 (통합)
             route.maskPersonalDataForDeletion();
             
-            log.debug("경로 사용자 정보 마스킹: routeId={}, title={}", 
+            // 경로 소프트 삭제 처리
+            route.markAsDeleted();
+            
+            log.debug("경로 사용자 정보 마스킹 및 소프트 삭제: routeId={}, title={}", 
                 route.getId(), route.getTitle());
         }
         

--- a/src/main/java/com/ridingmate/api_server/domain/user/controller/UserApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/controller/UserApi.java
@@ -64,13 +64,23 @@ public interface UserApi {
 
     @Operation(
             summary = "프로필 이미지 변경", 
-            description = "현재 로그인된 사용자의 프로필 이미지를 변경합니다. 파일을 보내지 않으면 기본 이미지로 변경됩니다."
+            description = "현재 로그인된 사용자의 프로필 이미지를 변경합니다."
     )
     @ApiResponse(responseCode = "200", description = "성공: 프로필 이미지 변경 완료")
     @PutMapping(value = "/user/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<CommonResponse<UserResponse>> updateProfileImage(
             @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser,
-            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+            @RequestPart(value = "profileImage") MultipartFile profileImage
+    );
+
+    @Operation(
+            summary = "프로필 이미지 삭제", 
+            description = "현재 로그인된 사용자의 프로필 이미지를 기본 이미지로 변경합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "성공: 프로필 이미지 삭제 완료")
+    @DeleteMapping("/user/profile/image")
+    ResponseEntity<CommonResponse<UserResponse>> deleteProfileImage(
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser
     );
 
     @Operation(

--- a/src/main/java/com/ridingmate/api_server/domain/user/controller/UserApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/controller/UserApi.java
@@ -1,16 +1,16 @@
 package com.ridingmate.api_server.domain.user.controller;
 
+import com.ridingmate.api_server.domain.auth.dto.AgreementStatusResponse;
+import com.ridingmate.api_server.domain.auth.dto.AgreementUpdateRequest;
 import com.ridingmate.api_server.domain.auth.security.AuthUser;
 import com.ridingmate.api_server.domain.user.dto.UserResponse;
 import com.ridingmate.api_server.domain.user.dto.request.BirthYearUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.GenderUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.IntroduceUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.NicknameUpdateRequest;
-import com.ridingmate.api_server.domain.user.dto.request.ProfileImageUpdateRequest;
 import com.ridingmate.api_server.global.exception.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -74,6 +74,17 @@ public interface UserApi {
     ResponseEntity<CommonResponse<UserResponse>> updateProfileImage(
             @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestPart("profileImage") MultipartFile profileImage
+    );
+
+    @Operation(
+            summary = "동의항목 업데이트", 
+            description = "사용자의 동의항목을 업데이트합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "성공: 동의항목 업데이트 완료")
+    @PutMapping("/user/agreements")
+    ResponseEntity<CommonResponse<AgreementStatusResponse>> updateAgreements(
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody AgreementUpdateRequest request
     );
 
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/controller/UserApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/controller/UserApi.java
@@ -17,10 +17,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "User API", description = "사용자 관련 API")
@@ -85,6 +82,16 @@ public interface UserApi {
     ResponseEntity<CommonResponse<AgreementStatusResponse>> updateAgreements(
             @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody AgreementUpdateRequest request
+    );
+
+    @Operation(
+            summary = "회원 탈퇴", 
+            description = "현재 로그인된 사용자의 계정을 삭제합니다. 개인정보는 마스킹되고, 위치정보는 법정 기간 동안 보존됩니다."
+    )
+    @ApiResponse(responseCode = "200", description = "성공: 회원 탈퇴 완료")
+    @DeleteMapping("/user")
+    ResponseEntity<CommonResponse<Void>> deleteUser(
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser
     );
 
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/controller/UserApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/controller/UserApi.java
@@ -67,13 +67,13 @@ public interface UserApi {
 
     @Operation(
             summary = "프로필 이미지 변경", 
-            description = "현재 로그인된 사용자의 프로필 이미지를 변경합니다."
+            description = "현재 로그인된 사용자의 프로필 이미지를 변경합니다. 파일을 보내지 않으면 기본 이미지로 변경됩니다."
     )
     @ApiResponse(responseCode = "200", description = "성공: 프로필 이미지 변경 완료")
     @PutMapping(value = "/user/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<CommonResponse<UserResponse>> updateProfileImage(
             @Parameter(hidden = true) @AuthenticationPrincipal AuthUser authUser,
-            @Valid @RequestPart("profileImage") MultipartFile profileImage
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     );
 
     @Operation(

--- a/src/main/java/com/ridingmate/api_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/controller/UserController.java
@@ -13,10 +13,7 @@ import com.ridingmate.api_server.domain.user.facade.UserFacade;
 import com.ridingmate.api_server.global.exception.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -87,5 +84,14 @@ public class UserController implements UserApi {
         return ResponseEntity
                 .status(UserSuccessCode.UPDATE_AGREEMENTS_SUCCESS.getStatus())
                 .body(CommonResponse.success(UserSuccessCode.UPDATE_AGREEMENTS_SUCCESS, response));
+    }
+
+    @Override
+    @DeleteMapping("/user")
+    public ResponseEntity<CommonResponse<Void>> deleteUser(AuthUser authUser) {
+        userFacade.deleteUser(authUser.id());
+        return ResponseEntity
+                .status(UserSuccessCode.DELETE_USER_SUCCESS.getStatus())
+                .body(CommonResponse.success(UserSuccessCode.DELETE_USER_SUCCESS));
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/controller/UserController.java
@@ -1,12 +1,13 @@
 package com.ridingmate.api_server.domain.user.controller;
 
+import com.ridingmate.api_server.domain.auth.dto.AgreementStatusResponse;
+import com.ridingmate.api_server.domain.auth.dto.AgreementUpdateRequest;
 import com.ridingmate.api_server.domain.auth.security.AuthUser;
 import com.ridingmate.api_server.domain.user.dto.UserResponse;
 import com.ridingmate.api_server.domain.user.dto.request.BirthYearUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.GenderUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.IntroduceUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.NicknameUpdateRequest;
-import com.ridingmate.api_server.domain.user.dto.request.ProfileImageUpdateRequest;
 import com.ridingmate.api_server.domain.user.exception.UserSuccessCode;
 import com.ridingmate.api_server.domain.user.facade.UserFacade;
 import com.ridingmate.api_server.global.exception.CommonResponse;
@@ -77,5 +78,14 @@ public class UserController implements UserApi {
         return ResponseEntity
                 .status(UserSuccessCode.UPDATE_PROFILE_IMAGE_SUCCESS.getStatus())
                 .body(CommonResponse.success(UserSuccessCode.UPDATE_PROFILE_IMAGE_SUCCESS, response));
+    }
+
+    @Override
+    @PutMapping("/user/agreements")
+    public ResponseEntity<CommonResponse<AgreementStatusResponse>> updateAgreements(AuthUser authUser, AgreementUpdateRequest request) {
+        AgreementStatusResponse response = userFacade.updateAgreements(authUser.id(), request);
+        return ResponseEntity
+                .status(UserSuccessCode.UPDATE_AGREEMENTS_SUCCESS.getStatus())
+                .body(CommonResponse.success(UserSuccessCode.UPDATE_AGREEMENTS_SUCCESS, response));
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/controller/UserController.java
@@ -78,6 +78,15 @@ public class UserController implements UserApi {
     }
 
     @Override
+    @DeleteMapping("/user/profile/image")
+    public ResponseEntity<CommonResponse<UserResponse>> deleteProfileImage(AuthUser authUser) {
+        UserResponse response = userFacade.deleteProfileImage(authUser.id());
+        return ResponseEntity
+                .status(UserSuccessCode.DELETE_PROFILE_IMAGE_SUCCESS.getStatus())
+                .body(CommonResponse.success(UserSuccessCode.DELETE_PROFILE_IMAGE_SUCCESS, response));
+    }
+
+    @Override
     @PutMapping("/user/agreements")
     public ResponseEntity<CommonResponse<AgreementStatusResponse>> updateAgreements(AuthUser authUser, AgreementUpdateRequest request) {
         AgreementStatusResponse response = userFacade.updateAgreements(authUser.id(), request);

--- a/src/main/java/com/ridingmate/api_server/domain/user/entity/TerraUser.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/entity/TerraUser.java
@@ -54,4 +54,8 @@ public class TerraUser extends BaseTimeEntity {
     public void setActive(){
         isActive = true;
     }
+
+    public void setInactive(){
+        isActive = false;
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/entity/User.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/entity/User.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 
@@ -65,6 +66,9 @@ public class User extends BaseTimeEntity {
 
     @Column(name = "location_service_agreed", nullable = false)
     private Boolean locationServiceAgreed;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     @Builder
     public User(SocialProvider socialProvider, String socialId, String email,
@@ -158,6 +162,31 @@ public class User extends BaseTimeEntity {
      */
     public void updateLocationServiceAgreed(Boolean locationServiceAgreed) {
         this.locationServiceAgreed = locationServiceAgreed;
+    }
+
+    /**
+     * 삭제 여부 확인
+     */
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    /**
+     * 사용자 삭제 처리 (소프트 삭제)
+     */
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+        maskPersonalData();
+    }
+
+    /**
+     * 개인정보 마스킹 처리
+     */
+    private void maskPersonalData() {
+        this.email = "deleted_" + this.id + "@deleted.com";
+        this.nickname = "탈퇴한 사용자";
+        this.profileImagePath = DEFAULT_PROFILE_IMAGE_PATH;
+        this.introduce = null;
     }
 
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/entity/User.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/entity/User.java
@@ -57,14 +57,27 @@ public class User extends BaseTimeEntity {
     @Column(name = "gender")
     private Gender gender;
 
+    @Column(name = "terms_of_service_agreed", nullable = false)
+    private Boolean termsOfServiceAgreed;
+
+    @Column(name = "privacy_policy_agreed", nullable = false)
+    private Boolean privacyPolicyAgreed;
+
+    @Column(name = "location_service_agreed", nullable = false)
+    private Boolean locationServiceAgreed;
+
     @Builder
     public User(SocialProvider socialProvider, String socialId, String email,
-                String nickname, String profileImagePath) {
+                String nickname, String profileImagePath, Boolean termsOfServiceAgreed,
+                Boolean privacyPolicyAgreed, Boolean locationServiceAgreed) {
         this.socialProvider = socialProvider;
         this.socialId = socialId;
         this.email = email;
         this.nickname = nickname;
         this.profileImagePath = profileImagePath;
+        this.termsOfServiceAgreed = termsOfServiceAgreed;
+        this.privacyPolicyAgreed = privacyPolicyAgreed;
+        this.locationServiceAgreed = locationServiceAgreed;
     }
 
     @PrePersist
@@ -85,6 +98,9 @@ public class User extends BaseTimeEntity {
                 .email(email)
                 .nickname(nickname)
                 .profileImagePath(DEFAULT_PROFILE_IMAGE_PATH)
+                .termsOfServiceAgreed(true)      // 서비스 이용약관 동의 (필수)
+                .privacyPolicyAgreed(true)       // 개인정보 처리방침 동의 (필수)
+                .locationServiceAgreed(true)     // 위치기반 서비스 이용약관 동의 (필수)
                 .build();
     }
 
@@ -121,6 +137,27 @@ public class User extends BaseTimeEntity {
      */
     public void updateProfileImagePath(String profileImagePath) {
         this.profileImagePath = profileImagePath;
+    }
+
+    /**
+     * 서비스 이용약관 동의 업데이트
+     */
+    public void updateTermsOfServiceAgreed(Boolean termsOfServiceAgreed) {
+        this.termsOfServiceAgreed = termsOfServiceAgreed;
+    }
+
+    /**
+     * 개인정보 처리방침 동의 업데이트
+     */
+    public void updatePrivacyPolicyAgreed(Boolean privacyPolicyAgreed) {
+        this.privacyPolicyAgreed = privacyPolicyAgreed;
+    }
+
+    /**
+     * 위치기반 서비스 이용약관 동의 업데이트
+     */
+    public void updateLocationServiceAgreed(Boolean locationServiceAgreed) {
+        this.locationServiceAgreed = locationServiceAgreed;
     }
 
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/exception/UserErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "유저를 찾을 수 없습니다."),
+    DELETED_USER(HttpStatus.NOT_FOUND, "DELETED_USER", "탈퇴한 사용자입니다."),
+    USER_ALREADY_DELETED(HttpStatus.CONFLICT, "USER_ALREADY_DELETED", "이미 탈퇴한 사용자입니다."),
     INVALID_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "INVALID_PROFILE_IMAGE", "유효하지 않은 프로필 이미지입니다."),
     PROFILE_IMAGE_TOO_LARGE(HttpStatus.BAD_REQUEST, "PROFILE_IMAGE_TOO_LARGE", "프로필 이미지 크기가 너무 큽니다. (최대 20MB)"),
     INVALID_PROFILE_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_PROFILE_IMAGE_FORMAT", "지원하지 않는 이미지 형식입니다. (JPG, PNG, WebP만 지원)")

--- a/src/main/java/com/ridingmate/api_server/domain/user/exception/UserSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/exception/UserSuccessCode.java
@@ -16,7 +16,8 @@ public enum UserSuccessCode implements SuccessCode {
     UPDATE_GENDER_SUCCESS(HttpStatus.OK, "성별 변경 성공"),
     UPDATE_BIRTH_YEAR_SUCCESS(HttpStatus.OK, "출생년도 변경 성공"),
     UPDATE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 이미지 변경 성공"),
-    UPDATE_AGREEMENTS_SUCCESS(HttpStatus.OK, "동의항목 업데이트 성공");
+    UPDATE_AGREEMENTS_SUCCESS(HttpStatus.OK, "동의항목 업데이트 성공"),
+    DELETE_USER_SUCCESS(HttpStatus.OK, "회원 탈퇴 성공");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ridingmate/api_server/domain/user/exception/UserSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/exception/UserSuccessCode.java
@@ -15,7 +15,8 @@ public enum UserSuccessCode implements SuccessCode {
     UPDATE_INTRODUCE_SUCCESS(HttpStatus.OK, "한 줄 소개 변경 성공"),
     UPDATE_GENDER_SUCCESS(HttpStatus.OK, "성별 변경 성공"),
     UPDATE_BIRTH_YEAR_SUCCESS(HttpStatus.OK, "출생년도 변경 성공"),
-    UPDATE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 이미지 변경 성공");
+    UPDATE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 이미지 변경 성공"),
+    UPDATE_AGREEMENTS_SUCCESS(HttpStatus.OK, "동의항목 업데이트 성공");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ridingmate/api_server/domain/user/exception/UserSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/exception/UserSuccessCode.java
@@ -16,6 +16,7 @@ public enum UserSuccessCode implements SuccessCode {
     UPDATE_GENDER_SUCCESS(HttpStatus.OK, "성별 변경 성공"),
     UPDATE_BIRTH_YEAR_SUCCESS(HttpStatus.OK, "출생년도 변경 성공"),
     UPDATE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 이미지 변경 성공"),
+    DELETE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 이미지 삭제 성공"),
     UPDATE_AGREEMENTS_SUCCESS(HttpStatus.OK, "동의항목 업데이트 성공"),
     DELETE_USER_SUCCESS(HttpStatus.OK, "회원 탈퇴 성공");
 

--- a/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
@@ -1,5 +1,8 @@
 package com.ridingmate.api_server.domain.user.facade;
 
+import com.ridingmate.api_server.domain.auth.dto.AgreementStatusResponse;
+import com.ridingmate.api_server.domain.auth.dto.AgreementUpdateRequest;
+import com.ridingmate.api_server.domain.auth.service.AgreementService;
 import com.ridingmate.api_server.domain.user.dto.UserResponse;
 import com.ridingmate.api_server.domain.user.dto.request.BirthYearUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.GenderUpdateRequest;
@@ -18,6 +21,7 @@ public class UserFacade {
 
     private final UserService userService;
     private final S3Manager s3Manager;
+    private final AgreementService agreementService;
 
     public UserResponse getMyInfo(Long userId) {
         User user = userService.getMyInfo(userId);
@@ -53,5 +57,9 @@ public class UserFacade {
         User user = userService.updateProfileImage(userId, profileImage);
         String profileImageUrl = s3Manager.getPresignedUrl(user.getProfileImagePath());
         return UserResponse.of(user, profileImageUrl);
+    }
+
+    public AgreementStatusResponse updateAgreements(Long userId, AgreementUpdateRequest request) {
+        return agreementService.updateAgreements(userId, request);
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
@@ -65,6 +65,12 @@ public class UserFacade {
         return UserResponse.of(user, profileImageUrl);
     }
 
+    public UserResponse deleteProfileImage(Long userId) {
+        User user = userService.deleteProfileImage(userId);
+        String profileImageUrl = s3Manager.getPresignedUrl(user.getProfileImagePath());
+        return UserResponse.of(user, profileImageUrl);
+    }
+
     public AgreementStatusResponse updateAgreements(Long userId, AgreementUpdateRequest request) {
         return agreementService.updateAgreements(userId, request);
     }

--- a/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
@@ -62,4 +62,11 @@ public class UserFacade {
     public AgreementStatusResponse updateAgreements(Long userId, AgreementUpdateRequest request) {
         return agreementService.updateAgreements(userId, request);
     }
+
+    /**
+     * 사용자 삭제 처리
+     */
+    public void deleteUser(Long userId) {
+        userService.deleteUser(userId);
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/facade/UserFacade.java
@@ -10,6 +10,9 @@ import com.ridingmate.api_server.domain.user.dto.request.IntroduceUpdateRequest;
 import com.ridingmate.api_server.domain.user.dto.request.NicknameUpdateRequest;
 import com.ridingmate.api_server.domain.user.entity.User;
 import com.ridingmate.api_server.domain.user.service.UserService;
+import com.ridingmate.api_server.domain.user.service.TerraUserService;
+import com.ridingmate.api_server.domain.route.service.RouteService;
+import com.ridingmate.api_server.domain.activity.service.ActivityService;
 import com.ridingmate.api_server.infra.aws.s3.S3Manager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +25,9 @@ public class UserFacade {
     private final UserService userService;
     private final S3Manager s3Manager;
     private final AgreementService agreementService;
+    private final RouteService routeService;
+    private final ActivityService activityService;
+    private final TerraUserService terraUserService;
 
     public UserResponse getMyInfo(Long userId) {
         User user = userService.getMyInfo(userId);
@@ -67,6 +73,27 @@ public class UserFacade {
      * 사용자 삭제 처리
      */
     public void deleteUser(Long userId) {
-        userService.deleteUser(userId);
+        // 1. 사용자 삭제 (소프트 삭제 + 개인정보 마스킹)
+        User user = userService.getUser(userId);
+        userService.deleteUser(user);
+        
+        // 2. 관련 데이터 처리 (각 서비스에 위임)
+        try {
+            routeService.handleUserDeletion(user);
+        } catch (Exception e) {
+            // 경로 데이터 처리 실패해도 사용자 삭제는 계속 진행
+        }
+        
+        try {
+            activityService.handleUserDeletion(user);
+        } catch (Exception e) {
+            // 활동 데이터 처리 실패해도 사용자 삭제는 계속 진행
+        }
+        
+        try {
+            terraUserService.handleUserDeletion(user);
+        } catch (Exception e) {
+            // Terra 연동 해제 실패해도 사용자 삭제는 계속 진행
+        }
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/service/TerraUserService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/service/TerraUserService.java
@@ -6,19 +6,24 @@ import com.ridingmate.api_server.domain.user.exception.UserErrorCode;
 import com.ridingmate.api_server.domain.user.exception.UserException;
 import com.ridingmate.api_server.domain.user.repository.TerraUserRepository;
 import com.ridingmate.api_server.domain.user.repository.UserRepository;
+import com.ridingmate.api_server.infra.terra.TerraClient;
 import com.ridingmate.api_server.infra.terra.TerraProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class TerraUserService {
 
     private final UserRepository userRepository;
     private final TerraUserRepository terraUserRepository;
+    private final TerraClient terraClient;
 
     @Transactional
     public void createTerraUser(Long userId, UUID terraUserId, TerraProvider terraProvider){
@@ -32,5 +37,76 @@ public class TerraUserService {
                 .build();
 
         terraUserRepository.save(terraUser);
+    }
+
+    /**
+     * 사용자 삭제 시 Terra 연동 해제
+     * - TerraUser 테이블의 isActive를 false로 설정
+     * - 기타 외부 서비스 연동 해제
+     */
+    @Transactional
+    public void handleUserDeletion(User user) {
+        log.info("Terra 연동 해제 시작: userId={}", user.getId());
+        
+        try {
+            // 1. 사용자의 모든 활성 Terra 연동 조회
+            List<TerraUser> activeTerraUsers = terraUserRepository.findAllByUserAndIsActiveTrue(user);
+            
+            // 2. Terra 연동 비활성화 처리
+            deactivateTerraUsers(activeTerraUsers);
+            
+            log.info("Terra 연동 해제 완료: userId={}, count={}", user.getId(), activeTerraUsers.size());
+        } catch (Exception e) {
+            log.error("Terra 연동 해제 중 오류 발생: userId={}", user.getId(), e);
+            // Terra 연동 해제 실패해도 사용자 삭제는 계속 진행
+        }
+    }
+
+    /**
+     * Terra 연동 비활성화 처리
+     */
+    private void deactivateTerraUsers(List<TerraUser> terraUsers) {
+        log.info("Terra 연동 비활성화 처리 시작: count={}", terraUsers.size());
+        
+        for (TerraUser terraUser : terraUsers) {
+            try {
+                // 1. Terra 서비스와의 실제 연동 해제
+                deactivateTerraConnection(terraUser);
+                
+                // 2. 로컬 DB에서 isActive를 false로 설정
+                terraUser.setInactive();
+                
+                log.debug("Terra 연동 비활성화 완료: terraUserId={}, provider={}", 
+                    terraUser.getTerraUserId(), terraUser.getProvider());
+                    
+            } catch (Exception e) {
+                log.warn("Terra 연동 해제 실패: terraUserId={}, provider={}", 
+                    terraUser.getTerraUserId(), terraUser.getProvider(), e);
+                
+                // Terra 연동 해제 실패해도 로컬 DB는 비활성화
+                terraUser.setInactive();
+            }
+        }
+        
+        log.info("Terra 연동 비활성화 처리 완료: count={}", terraUsers.size());
+    }
+
+    /**
+     * Terra 서비스와의 실제 연동 해제
+     */
+    private void deactivateTerraConnection(TerraUser terraUser) {
+        log.debug("Terra 서비스 연동 해제 시작: terraUserId={}, provider={}", 
+            terraUser.getTerraUserId(), terraUser.getProvider());
+        
+        try {
+            // Terra API를 통한 실제 연동 해제
+            terraClient.deauthenticateUser(terraUser.getTerraUserId());
+            
+            log.debug("Terra 서비스 연동 해제 완료: terraUserId={}", terraUser.getTerraUserId());
+            
+        } catch (Exception e) {
+            log.error("Terra 서비스 연동 해제 실패: terraUserId={}", terraUser.getTerraUserId(), e);
+            throw e; // 상위 메서드에서 처리하도록 예외 전파
+        }
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/service/UserService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/service/UserService.java
@@ -19,7 +19,6 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class UserService {
 
     private final UserRepository userRepository;
@@ -53,9 +52,16 @@ public class UserService {
         });
     }
 
+    @Transactional(readOnly = true)
     public User getUser(Long userId){
-        return userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        
+        if (user.isDeleted()) {
+            throw new UserException(UserErrorCode.DELETED_USER);
+        }
+        
+        return user;
     }
 
     @Transactional(readOnly = true)
@@ -63,30 +69,35 @@ public class UserService {
         return getUser(userId);
     }
 
+    @Transactional
     public User updateNickname(Long userId, NicknameUpdateRequest request) {
         User user = getUser(userId);
         user.updateNickname(request.nickname());
         return user;
     }
 
+    @Transactional
     public User updateIntroduce(Long userId, IntroduceUpdateRequest request) {
         User user = getUser(userId);
         user.updateIntroduce(request.introduce());
         return user;
     }
 
+    @Transactional
     public User updateGender(Long userId, GenderUpdateRequest request) {
         User user = getUser(userId);
         user.updateGender(request.gender());
         return user;
     }
 
+    @Transactional
     public User updateBirthYear(Long userId, BirthYearUpdateRequest request) {
         User user = getUser(userId);
         user.updateBirthYear(request.birthYear());
         return user;
     }
 
+    @Transactional
     public User updateProfileImage(Long userId, MultipartFile profileImage) {
         User user = getUser(userId);
         
@@ -190,5 +201,42 @@ public class UserService {
             return ".jpg";
         }
         return filename.substring(lastDotIndex);
+    }
+
+    /**
+     * 사용자 삭제 처리 (소프트 삭제)
+     */
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = getUser(userId);
+
+        if (user.isDeleted()) {
+            log.warn("이미 삭제된 사용자입니다: userId={}", userId);
+            throw new UserException(UserErrorCode.USER_ALREADY_DELETED);
+        }
+
+        user.delete();
+
+        //관련 데이터 처리
+        handleRelatedData(userId);
+
+        log.info("사용자 삭제 완료: userId={}, deletedAt={}", userId, user.getDeletedAt());
+    }
+
+    /**
+     * 관련 데이터 처리
+     * - 경로 데이터: 보존 (법정 의무)
+     * - 활동 데이터: 보존 (법정 의무)
+     * - 개인정보: 이미 마스킹됨
+     */
+    private void handleRelatedData(Long userId) {
+        log.info("관련 데이터 처리 시작: userId={}", userId);
+
+        // TODO: 필요시 추가 처리 로직 구현
+        // - 경로 데이터 보존 확인
+        // - 활동 데이터 보존 확인
+        // - 제3자 서비스 연동 해제
+
+        log.info("관련 데이터 처리 완료: userId={}", userId);
     }
 } 

--- a/src/main/java/com/ridingmate/api_server/domain/user/service/UserService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/service/UserService.java
@@ -101,11 +101,6 @@ public class UserService {
     public User updateProfileImage(Long userId, MultipartFile profileImage) {
         User user = getUser(userId);
         
-        // 파일이 없거나 비어있으면 기본 이미지로 변경
-        if (profileImage == null || profileImage.isEmpty()) {
-            return resetProfileImageToDefault(user);
-        }
-        
         // 파일 유효성 검증
         validateProfileImage(profileImage);
         
@@ -129,6 +124,15 @@ public class UserService {
         
         log.info("사용자 {} 프로필 이미지 업데이트 완료: {}", userId, imagePath);
         return user;
+    }
+
+    /**
+     * 프로필 이미지를 기본 이미지로 변경 (삭제)
+     */
+    @Transactional
+    public User deleteProfileImage(Long userId) {
+        User user = getUser(userId);
+        return resetProfileImageToDefault(user);
     }
     
     /**

--- a/src/main/java/com/ridingmate/api_server/infra/terra/TerraClient.java
+++ b/src/main/java/com/ridingmate/api_server/infra/terra/TerraClient.java
@@ -116,4 +116,43 @@ public class TerraClient {
                 )
                 .block();
     }
+
+    /**
+     * Terra 사용자 연동 해제
+     * @param terraUserId Terra 사용자 ID
+     */
+    public void deauthenticateUser(UUID terraUserId) {
+        log.info("Terra 사용자 연동 해제 시작: terraUserId={}", terraUserId);
+        
+        terraWebClient.delete()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v2/auth/deauthenticateUser")
+                        .queryParam("user_id", terraUserId)
+                        .build())
+                .retrieve()
+                .onStatus(
+                        status -> status.is4xxClientError() || status.is5xxServerError(),
+                        response -> response.bodyToMono(String.class)
+                                .flatMap(errorBody -> {
+                                    log.error("Terra 사용자 연동 해제 실패: terraUserId={}, status={}, body={}", 
+                                        terraUserId, response.statusCode(), errorBody);
+                                    if (response.statusCode().is4xxClientError()) {
+                                        return Mono.error(new TerraException(TerraErrorCode.TERRA_REQUEST_FAILED));
+                                    }
+                                    return Mono.error(new TerraException(TerraErrorCode.TERRA_SERVER_ERROR));
+                                })
+                )
+                .bodyToMono(String.class)
+                .onErrorMap(
+                        throwable -> !(throwable instanceof BusinessException),
+                        throwable -> {
+                            if (throwable instanceof CodecException) {
+                                return new TerraException(TerraErrorCode.TERRA_MAPPING_FAILED);
+                            }
+                            return new TerraException(TerraErrorCode.TERRA_CONNECTION_FAILED);
+                        }
+                )
+                .doOnSuccess(response -> log.info("Terra 사용자 연동 해제 완료: terraUserId={}", terraUserId))
+                .block();
+    }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용

1. 로그인 시 아래처럼 약관 동의 정보를 보여주는 필드를 추가했습니다
모든 필수 약관에 동의한경우 isComplete = true로 반환합니다.
```
    "agreementStatus": {
      "termsOfServiceAgreed": true,
      "privacyPolicyAgreed": true,
      "locationServiceAgreed": false,
      "isCompleted": false
    }
```

2. 프로필 삭제 api 추가
[Delete] /api/v1/user/profile/image 를 통해 프로필삭제(기본 이미지로 변경)이 가능하도록 하였습니다.

3. 회원 탈퇴
각 엔티티별 회원 탈퇴 시 정보 처리 방식

[User]
1. User
 회원 탈퇴 시 email, nickname, 프로필 이미지 등 식별 가능한 정보를 모두 삭제 및 식별 불가능한 다른 값(ex. "삭제된 사용자")으로 변경

2. TerraUser
 Terra 측에 연동 해제 요청

[Route]
1. Route
 모든 정보를 Null로 마스킹, 이후 익명화하면 활용 가능한 정보(distance, duration, elevationGain)들은 남겨둘 가능성 논의 필요 (통계, 내부 활용 용도)

2. RouteGpsLog
 모두 하드 딜리트

[Activity]
1. Activity
 모든 정보를 Null로 마스킹, 이후 익명화하면 활용 가능한 정보(distance, duration, elevationGain)들은 남겨둘 가능성 논의 필요 (통계, 내부 활용 용도)

2. RouteGpsLog
 모두 하드 딜리트

3. ActivityImage
 모두 하드 딜리트 및 s3에서 제거

-> GpsLog 데이터의 경우 데이터 양이 많아서 너무 오래걸리기 떄문에 비동기 방식으로 배치처리나 큐로 처리가 필요해보입니다
해당 내용은 아직 반영되어있지 않은데 해당 부분까지 구현하면 너무 오래걸릴것같아서 일단 pr 올리겠습니다.

## PR 포인트

## 고민과 학습내용

## 스크린샷
