### PR TITLE
[Feat] 추천 코스 상세 조회 api 구현 및 추천 경로 목록 조회 수정

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RecommendationApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RecommendationApi.java
@@ -3,6 +3,7 @@ package com.ridingmate.api_server.domain.route.controller;
 import com.ridingmate.api_server.domain.auth.security.AuthUser;
 import com.ridingmate.api_server.domain.route.dto.request.RecommendationListRequest;
 import com.ridingmate.api_server.domain.route.dto.response.CreateRouteResponse;
+import com.ridingmate.api_server.domain.route.dto.response.RecommendationDetailResponse;
 import com.ridingmate.api_server.domain.route.dto.response.RecommendationListResponse;
 import com.ridingmate.api_server.global.exception.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -55,6 +56,25 @@ public interface RecommendationApi {
      ResponseEntity<CommonResponse<CreateRouteResponse>> copyRecommendedRouteToMyRoutes(
              @AuthenticationPrincipal AuthUser authUser,
              @Parameter(description = "복사할 경로 ID")
+             @PathVariable String routeId
+     );
+
+     @Operation(
+             summary = "추천 코스 세부 정보 조회",
+             description = """
+                     특정 추천 코스의 상세 정보를 조회합니다.
+                                            
+                     - 추천 코스의 기본 정보(이름, 설명, 거리, 고도 등)
+                     - 추천 타입, 자연 경관 타입, 지역 정보
+                     - 경로를 구성하는 모든 GPS 좌표 목록 (위도, 경도, 고도)
+                     """
+     )
+     @ApiResponses({
+             @ApiResponse(responseCode = "200", description = "성공: 추천 코스 세부 정보 조회 완료"),
+             @ApiResponse(responseCode = "404", description = "존재하지 않는 추천 코스입니다."),
+     })
+     ResponseEntity<CommonResponse<RecommendationDetailResponse>> getRecommendationDetail(
+             @Parameter(description = "추천 코스 ID")
              @PathVariable String routeId
      );
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RecommendationController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RecommendationController.java
@@ -4,6 +4,7 @@ import com.ridingmate.api_server.domain.auth.exception.AuthErrorCode;
 import com.ridingmate.api_server.domain.auth.security.AuthUser;
 import com.ridingmate.api_server.domain.route.dto.request.RecommendationListRequest;
 import com.ridingmate.api_server.domain.route.dto.response.CreateRouteResponse;
+import com.ridingmate.api_server.domain.route.dto.response.RecommendationDetailResponse;
 import com.ridingmate.api_server.domain.route.dto.response.RecommendationListResponse;
 import com.ridingmate.api_server.domain.route.exception.RouteSuccessCode;
 import com.ridingmate.api_server.domain.route.exception.code.RouteCommonErrorCode;
@@ -46,5 +47,17 @@ public class RecommendationController implements RecommendationApi {
         return ResponseEntity
                 .status(RouteSuccessCode.RECOMMENDED_ROUTE_COPIED.getStatus())
                 .body(CommonResponse.success(RouteSuccessCode.RECOMMENDED_ROUTE_COPIED, response));
+    }
+
+    @Override
+    @GetMapping("/{routeId}")
+    @ApiErrorCodeExample(RouteCommonErrorCode.class)
+    public ResponseEntity<CommonResponse<RecommendationDetailResponse>> getRecommendationDetail(
+            @PathVariable String routeId
+    ) {
+        RecommendationDetailResponse response = recommendationFacade.getRecommendationDetail(routeId);
+        return ResponseEntity
+                .status(RouteSuccessCode.ROUTE_DETAIL_FETCHED.getStatus())
+                .body(CommonResponse.success(RouteSuccessCode.ROUTE_DETAIL_FETCHED, response));
     }
 } 

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/request/RecommendationListRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/request/RecommendationListRequest.java
@@ -47,29 +47,25 @@ public record RecommendationListRequest(
     
     @Parameter(
             description = "최소 거리 (km)",
-            example = "0.0",
-            required = true
+            example = "0.0"
     )
     Double minDistanceKm,
     
     @Parameter(
             description = "최대 거리 (km)",
-            example = "200.0",
-            required = true
+            example = "200.0"
     )
     Double maxDistanceKm,
     
     @Parameter(
             description = "최소 고도 상승 (미터)",
-            example = "0.0",
-            required = true
+            example = "0.0"
     )
     Double minElevationGain,
     
     @Parameter(
             description = "최대 고도 상승 (미터)",
-            example = "1000.0",
-            required = true
+            example = "1000.0"
     )
     Double maxElevationGain,
     

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RecommendationDetailResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RecommendationDetailResponse.java
@@ -1,0 +1,108 @@
+package com.ridingmate.api_server.domain.route.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ggalmazor.ltdownsampling.Point;
+import com.ridingmate.api_server.domain.route.entity.Recommendation;
+import com.ridingmate.api_server.domain.route.entity.Route;
+import com.ridingmate.api_server.domain.route.enums.LandscapeType;
+import com.ridingmate.api_server.domain.route.enums.RecommendationType;
+import com.ridingmate.api_server.domain.route.enums.Region;
+import com.ridingmate.api_server.global.util.GeometryUtil;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public record RecommendationDetailResponse(
+    @Schema(description = "경로 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    String routeId,
+
+    @Schema(description = "경로 제목", example = "한강 라이딩 경로")
+    String title,
+
+    @Schema(description = "경로 설명", example = "한강을 따라가는 아름다운 라이딩 코스입니다.")
+    String description,
+
+    @Schema(description = "추천 타입", example = "FAMOUS")
+    String recommendationType,
+
+    @Schema(description = "자연 경관 타입", example = "RIVERSIDE")
+    String landscapeType,
+
+    @Schema(description = "지역", example = "SEOUL")
+    String region,
+
+    @Schema(description = "경로 Polyline", example = "o{~vFf`miWvCkGbAaJjGgQxBwF")
+    String polyline,
+
+    @Schema(description = "경로 생성일", example = "2024-01-15T10:30:00")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    LocalDateTime createdAt,
+
+    @Schema(description = "예상 소요시간(분)", example = "71")
+    Long durationMinutes,
+
+    @Schema(description = "이동 거리 (km)", example = "13.2")
+    Double distance,
+
+    @Schema(description = "총 상승 고도 (m)", example = "120.4")
+    Double elevationGain,
+
+    @Schema(description = "사용자 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    String userId,
+
+    @Schema(description = "사용자 닉네임", example = "라이더123")
+    String nickname,
+
+    @Schema(description = "프로필 이미지 URL", example = "https://s3.amazonaws.com/bucket/profile-1.jpg")
+    String profileImageUrl,
+
+    @Schema(description = "샘플링된 경로 좌표 갯수", example = "100")
+    Integer trackPointsCount,
+
+    @Schema(description = "샘플링된 경로의 고도 데이터 목록")
+    List<ElevationPoint> trackPoints,
+
+    @Schema(
+            description = "경로 Bounding Box 좌표 [minLon, minLat, maxLon, maxLat]",
+            example = "[127.01, 37.50, 127.05, 37.55]"
+    )
+    List<Double> bbox
+) {
+
+    @Schema(description = "경로 고도 데이터")
+    public record ElevationPoint(
+            @Schema(description = "데이터 포인트의 인덱스", example = "0")
+            long index,
+            @Schema(description = "해당 지점의 고도 (m)", example = "81.2")
+            double elevation
+    ) {}
+
+    public static RecommendationDetailResponse from(Route route, List<Point> routeGpsPoints, String profileImageUrl) {
+        List<ElevationPoint> elevationPoints = IntStream.range(0, routeGpsPoints.size())
+                .mapToObj(i -> new ElevationPoint(i, routeGpsPoints.get(i).getY()))
+                .collect(Collectors.toList());
+
+        return new RecommendationDetailResponse(
+                route.getRouteId().toString(),
+                route.getTitle(),
+                route.getDescription(),
+                route.getRecommendation().getRecommendationType().getDisplayName(),
+                route.getLandscapeType().getDisplayName(),
+                route.getRegion().getDisplayName(),
+                GeometryUtil.lineStringToPolyline(route.getRouteLine()),
+                route.getCreatedAt(),
+                route.getDuration().toMinutes(),
+                route.getDistance(),
+                route.getElevationGain(),
+                route.getUser().getUuid().toString(),
+                route.getUser().getNickname(),
+                profileImageUrl,
+                elevationPoints.size(),
+                elevationPoints,
+                List.of(route.getMinLon(), route.getMinLat(), route.getMaxLon(), route.getMaxLat())
+        );
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RecommendationListResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RecommendationListResponse.java
@@ -1,9 +1,11 @@
 package com.ridingmate.api_server.domain.route.dto.response;
 
+import com.ridingmate.api_server.domain.route.dto.FilterRangeInfo;
 import com.ridingmate.api_server.domain.route.entity.Recommendation;
 import com.ridingmate.api_server.domain.route.entity.Route;
 import com.ridingmate.api_server.global.dto.PaginationResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -12,8 +14,23 @@ public record RecommendationListResponse(
     List<RecommendationItemResponse> recommendations,
     
     @Schema(description = "페이지네이션 정보")
-    PaginationResponse pagination
+    PaginationResponse pagination,
+
+    @Schema(description = "필터링 범위 정보")
+    FilterRangeInfo filterRange
 ) {
+
+    /**
+     * RecommendationItemResponse 리스트, Route 페이지, 전체 데이터 기준 FilterRangeInfo로부터 RecommendationListResponse 생성
+     * @param recommendationItems 변환된 추천 코스 목록
+     * @param routePage Route 페이지 (페이지네이션 정보 추출용)
+     * @param filterRange 전체 데이터 기준 필터링 범위 정보
+     * @return RecommendationListResponse DTO
+     */
+    public static RecommendationListResponse of(List<RecommendationItemResponse> recommendationItems, Page<Route> routePage, FilterRangeInfo filterRange) {
+        PaginationResponse pagination = PaginationResponse.from(routePage);
+        return new RecommendationListResponse(recommendationItems, pagination, filterRange);
+    }
     
     @Schema(description = "추천 코스 아이템")
     public record RecommendationItemResponse(

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RecommendationListResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RecommendationListResponse.java
@@ -7,7 +7,44 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(description = "추천 코스 목록 응답")
+@Schema(description = "추천 코스 목록 응답", example = """
+    {
+        "recommendations": [
+            {
+                "routeId": "550e8400-e29b-41d4-a716-446655440000",
+                "title": "한강 라이딩 코스",
+                "description": "한강을 따라가는 아름다운 라이딩 코스입니다.",
+                "distanceKm": 13.2,
+                "durationMinutes": 60,
+                "elevationGain": 120.4,
+                "region": "서울특별시",
+                "difficulty": "보통",
+                "recommendationType": "유명 코스",
+                "thumbnailImagePath": "https://s3.amazonaws.com/bucket/thumbnails/route-1.png"
+            },
+            {
+                "routeId": "550e8400-e29b-41d4-a716-446655440001",
+                "title": "남산 둘레길",
+                "description": "남산을 한 바퀴 도는 경치 좋은 코스입니다.",
+                "distanceKm": 8.5,
+                "durationMinutes": 40,
+                "elevationGain": 200.0,
+                "region": "서울특별시",
+                "difficulty": "어려움",
+                "recommendationType": "국토 종주",
+                "thumbnailImagePath": "https://s3.amazonaws.com/bucket/thumbnails/route-2.png"
+            }
+        ],
+        "pagination": {
+            "page": 0,
+            "size": 10,
+            "totalElements": 25,
+            "totalPages": 3,
+            "first": true,
+            "last": false
+        }
+    }
+    """)
 public record RecommendationListResponse(
     @Schema(description = "추천 코스 목록")
     List<RecommendationItemResponse> recommendations,
@@ -18,44 +55,44 @@ public record RecommendationListResponse(
     
     @Schema(description = "추천 코스 아이템")
     public record RecommendationItemResponse(
-        @Schema(description = "코스 ID")
-        Long id,
+        @Schema(description = "경로 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
+        String routeId,
         
-        @Schema(description = "코스 제목")
+        @Schema(description = "코스 제목", example = "한강 라이딩 코스")
         String title,
         
-        @Schema(description = "코스 설명")
+        @Schema(description = "코스 설명", example = "한강을 따라가는 아름다운 라이딩 코스입니다.")
         String description,
         
-        @Schema(description = "총 거리 (km)")
+        @Schema(description = "총 거리 (km)", example = "13.2")
         Double distanceKm,
         
-        @Schema(description = "총 소요 시간 (초)")
-        Long durationSeconds,
+        @Schema(description = "총 소요 시간 (분)", example = "60")
+        Long durationMinutes,
         
-        @Schema(description = "총 상승 고도 (m)")
+        @Schema(description = "총 상승 고도 (m)", example = "120.4")
         Double elevationGain,
         
-        @Schema(description = "지역")
+        @Schema(description = "지역", example = "서울특별시")
         String region,
         
-        @Schema(description = "난이도")
+        @Schema(description = "난이도", example = "보통")
         String difficulty,
         
-        @Schema(description = "추천 타입")
+        @Schema(description = "추천 타입", example = "유명 코스")
         String recommendationType,
         
-        @Schema(description = "썸네일 이미지 경로")
+        @Schema(description = "썸네일 이미지 경로", example = "https://s3.amazonaws.com/bucket/thumbnails/route-1.png")
         String thumbnailImagePath
     ) {
         
         public static RecommendationItemResponse from(Route route, Recommendation recommendation, String thumbnailUrl) {
             return new RecommendationItemResponse(
-                route.getId(),
+                route.getRouteId().toString(),
                 route.getTitle(),
                 route.getDescription(),
                 route.getDistanceInKm(),
-                route.getDuration().getSeconds(),
+                route.getDuration().toMinutes(),
                 route.getRoundedElevationGain(),
                 route.getRegion().getDisplayName(),
                 route.getDifficulty().getDisplayName(),

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RecommendationListResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RecommendationListResponse.java
@@ -7,44 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(description = "추천 코스 목록 응답", example = """
-    {
-        "recommendations": [
-            {
-                "routeId": "550e8400-e29b-41d4-a716-446655440000",
-                "title": "한강 라이딩 코스",
-                "description": "한강을 따라가는 아름다운 라이딩 코스입니다.",
-                "distanceKm": 13.2,
-                "durationMinutes": 60,
-                "elevationGain": 120.4,
-                "region": "서울특별시",
-                "difficulty": "보통",
-                "recommendationType": "유명 코스",
-                "thumbnailImagePath": "https://s3.amazonaws.com/bucket/thumbnails/route-1.png"
-            },
-            {
-                "routeId": "550e8400-e29b-41d4-a716-446655440001",
-                "title": "남산 둘레길",
-                "description": "남산을 한 바퀴 도는 경치 좋은 코스입니다.",
-                "distanceKm": 8.5,
-                "durationMinutes": 40,
-                "elevationGain": 200.0,
-                "region": "서울특별시",
-                "difficulty": "어려움",
-                "recommendationType": "국토 종주",
-                "thumbnailImagePath": "https://s3.amazonaws.com/bucket/thumbnails/route-2.png"
-            }
-        ],
-        "pagination": {
-            "page": 0,
-            "size": 10,
-            "totalElements": 25,
-            "totalPages": 3,
-            "first": true,
-            "last": false
-        }
-    }
-    """)
 public record RecommendationListResponse(
     @Schema(description = "추천 코스 목록")
     List<RecommendationItemResponse> recommendations,

--- a/src/main/java/com/ridingmate/api_server/domain/route/facade/RecommendationFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/facade/RecommendationFacade.java
@@ -1,8 +1,10 @@
 package com.ridingmate.api_server.domain.route.facade;
 
+import com.ggalmazor.ltdownsampling.Point;
 import com.ridingmate.api_server.domain.route.dto.request.RecommendationListRequest;
 import com.ridingmate.api_server.domain.route.dto.FilterRangeInfo;
 import com.ridingmate.api_server.domain.route.dto.response.CreateRouteResponse;
+import com.ridingmate.api_server.domain.route.dto.response.RecommendationDetailResponse;
 import com.ridingmate.api_server.domain.route.dto.response.RecommendationListResponse;
 import com.ridingmate.api_server.domain.route.entity.Recommendation;
 import com.ridingmate.api_server.domain.route.entity.Route;
@@ -10,6 +12,7 @@ import com.ridingmate.api_server.domain.route.service.RouteService;
 import com.ridingmate.api_server.domain.user.entity.User;
 import com.ridingmate.api_server.domain.user.service.UserService;
 import com.ridingmate.api_server.global.dto.PaginationResponse;
+import com.ridingmate.api_server.global.util.GeometryUtil;
 import com.ridingmate.api_server.global.util.GpxGenerator;
 import com.ridingmate.api_server.infra.aws.s3.S3Manager;
 import com.ridingmate.api_server.infra.geoapify.GeoapifyClient;
@@ -82,6 +85,22 @@ public class RecommendationFacade {
         }
 
         return CreateRouteResponse.from(route);
+    }
+
+    /**
+     * 추천 코스 세부 정보 조회
+     * @param routeId 추천 코스 ID
+     * @return 추천 코스 세부 정보 응답
+     */
+    public RecommendationDetailResponse getRecommendationDetail(String routeId) {
+        Route route = routeService.getRecommendationRouteWithUserByRouteId(routeId);
+        Coordinate[] coordinates = routeService.getRouteDetailList(route.getId());
+
+        List<Point> elevationProfilePoints = GeometryUtil.downsampleElevationProfile(coordinates, route.getDistance());
+
+        String profileImageUrl = s3Manager.getPresignedUrl(route.getUser().getProfileImagePath());
+
+        return RecommendationDetailResponse.from(route, elevationProfilePoints, profileImageUrl);
     }
 
 } 

--- a/src/main/java/com/ridingmate/api_server/domain/route/facade/RecommendationFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/facade/RecommendationFacade.java
@@ -60,7 +60,7 @@ public class RecommendationFacade {
         // 전체 추천 코스 기준의 최대값 조회 (페이지 데이터가 아닌 전체 데이터 기준)
         FilterRangeInfo filterRangeInfo = routeService.getMaxDistanceAndElevationForRecommendations();
 
-        return new RecommendationListResponse(recommendationItems, PaginationResponse.from(routePage));
+        return RecommendationListResponse.of(recommendationItems, routePage, filterRangeInfo);
     }
 
     public CreateRouteResponse copyRecommendedRouteToMyRoutes(Long userId, String routeId) {

--- a/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteRepository.java
@@ -47,6 +47,16 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
         """)
     Optional<Route> findByRouteId(@Param("routeId") UUID routeId);
 
+    @Query("""
+        SELECT r
+        FROM Route r
+        JOIN FETCH r.user
+        JOIN FETCH r.recommendation
+        WHERE r.routeId = :routeId
+        AND r.isDelete = false
+        """)
+    Optional<Route> findRecommendationRouteWithUserByRouteId(@Param("routeId") UUID routeId);
+
     /**
      * 사용자별 특정 관계 타입의 경로 조회 (거리 및 고도 필터링 포함)
      */

--- a/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
@@ -203,6 +203,12 @@ public class RouteService {
     }
 
     @Transactional(readOnly = true)
+    public Route getRecommendationRouteWithUserByRouteId(String routeId) {
+        return routeRepository.findRecommendationRouteWithUserByRouteId(UUID.fromString(routeId))
+                .orElseThrow(() -> new RouteException(RouteCommonErrorCode.ROUTE_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
     public Route getRouteByRouteId(String routeId) {
         return routeRepository.findByRouteId(UUID.fromString(routeId))
                 .orElseThrow(() -> new RouteException(RouteCommonErrorCode.ROUTE_NOT_FOUND));


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용

1. 추천 코스 상세 조회 api를 구현하였습니다. 경로 상세 조회와 대부분 비슷하고 지역,추천 타입, 난이도, 설명의 내용만 추가되었습니다.

2. 추천 코스에서도 routeId를 uuid기반으로 변경하였습니다.

3. 추천 코스 목록에서도 경로 조회와 같이 필터링(고도, 거리)를 반환하도록 추가했습니다.

## PR 포인트

## 고민과 학습내용

## 스크린샷
