### PR TITLE
[Feat] 나의 경로 삭제 api 구현

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteApi.java
@@ -168,4 +168,23 @@ public interface RouteApi {
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody AddRouteToMyRoutesRequest request
     );
+
+    @Operation(
+            summary = "경로 삭제",
+            description = """
+                    사용자의 경로를 삭제합니다.
+                    
+                    - OWNER/RECOMMENDED 관계: 경로 데이터 마스킹, GPS 로그 하드삭제
+                    - SHARED 관계: 사용자-경로 관계만 삭제
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공: 경로 삭제 완료"),
+            @ApiResponse(responseCode = "404", description = "경로를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "403", description = "경로 삭제 권한이 없습니다."),
+    })
+    ResponseEntity<CommonResponse<Void>> deleteRoute(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable String routeId
+    );
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
@@ -132,4 +132,19 @@ public class RouteController implements RouteApi{
                 .status(RouteSuccessCode.ROUTE_ADDED_TO_MY_ROUTES.getStatus())
                 .body(CommonResponse.success(RouteSuccessCode.ROUTE_ADDED_TO_MY_ROUTES, null));
     }
+
+    @Override
+    @DeleteMapping("/{routeId}")
+    @ApiErrorCodeExample(RouteCommonErrorCode.class)
+    @ApiErrorCodeExample(AuthErrorCode.class)
+    public ResponseEntity<CommonResponse<Void>> deleteRoute(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable String routeId) {
+        
+        routeFacade.deleteRoute(authUser.id(), routeId);
+        
+        return ResponseEntity
+                .status(RouteSuccessCode.ROUTE_DELETED.getStatus())
+                .body(CommonResponse.success(RouteSuccessCode.ROUTE_DELETED, null));
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteDetailResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteDetailResponse.java
@@ -36,8 +36,8 @@ public record RouteDetailResponse(
     @Schema(description = "총 상승 고도 (m)", example = "120.4")
     Double elevationGain,
 
-    @Schema(description = "사용자 ID", example = "1")
-    Long userId,
+    @Schema(description = "사용자 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    String userId,
 
     @Schema(description = "사용자 닉네임", example = "라이더123")
     String nickname,
@@ -79,7 +79,7 @@ public record RouteDetailResponse(
             route.getDuration().toMinutes(),
             route.getDistance(),
             route.getElevationGain(),
-            route.getUser().getId(),
+            route.getUser().getUuid().toString(),
             route.getUser().getNickname(),
             profileImageUrl,
             elevationPoints.size(),

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteListItemResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteListItemResponse.java
@@ -26,8 +26,8 @@ public record RouteListItemResponse(
         @Schema(description = "총 상승 고도 (m)", example = "120.4")
         Double elevationGain,
 
-        @Schema(description = "사용자 ID", example = "1")
-        Long userId,
+        @Schema(description = "사용자 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+        String userId,
 
         @Schema(description = "사용자 닉네임", example = "라이더123")
         String nickname,
@@ -51,7 +51,7 @@ public record RouteListItemResponse(
                 route.getCreatedAt(),
                 route.getDistanceInKm(),
                 route.getRoundedElevationGain(),
-                route.getUser().getId(),
+                route.getUser().getUuid().toString(),
                 route.getUser().getNickname(),
                 profileImageUrl
         );

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteSuccessCode.java
@@ -15,6 +15,7 @@ public enum RouteSuccessCode implements SuccessCode {
     MAP_SEARCH_FETCHED(HttpStatus.OK, "장소 검색 결과 목록이 조회되었습니다."),
     ROUTE_DETAIL_FETCHED(HttpStatus.OK, "경로 세부 정보가 조회되었습니다."),
     ROUTE_ADDED_TO_MY_ROUTES(HttpStatus.OK, "내 경로에 추가되었습니다."),
+    ROUTE_DELETED(HttpStatus.OK, "경로가 삭제되었습니다."),
     RECOMMENDED_ROUTE_COPIED(HttpStatus.CREATED, "추천 코스가 나의 경로에 저장되었습니다."),
     RECOMMENDED_ROUTES_FETCHED(HttpStatus.OK, "추천 경로 목록이 조회되었습니다."),
     ;

--- a/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
@@ -140,4 +140,13 @@ public class RouteFacade {
         routeService.addRouteToMyRoutes(user, request);
     }
 
+    /**
+     * 경로 삭제
+     */
+    public void deleteRoute(Long userId, String routeId) {
+        User user = userService.getUser(userId);
+        Route route = routeService.getRouteByRouteId(routeId);
+        routeService.deleteRoute(user, route);
+    }
+
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/repository/UserRouteRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/repository/UserRouteRepository.java
@@ -19,6 +19,11 @@ public interface UserRouteRepository extends JpaRepository<UserRoute, Long> {
     Optional<UserRoute> findByUserAndRouteAndRelationTypeAndIsDeleteFalse(User user, Route route, RouteRelationType relationType);
 
     /**
+     * 특정 사용자와 경로 간의 활성 관계 조회
+     */
+    Optional<UserRoute> findByUserAndRouteAndIsDeleteFalse(User user, Route route);
+
+    /**
      * 특정 사용자의 모든 활성 경로 관계 조회
      */
     List<UserRoute> findByUserAndIsDeleteFalse(User user);


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용

1. 나의 경로 삭제 api를 구현했습니다
- 내가 직접 생성하거나(OWNER), 추천 코스에서 저장(RECOMMENDED)한 경로는 하드 딜리트 됩니다.
- 공유받은(SHARED) 경로는 연결 관계만 제거하여 조회 목록에서 제외하도록 하였습니다.

2. 경로 상세 조회와 경로 목록 조회에서 userId가 실제 db값으로 넘어가던 부분을 UUID 기반으로 수정했습니다

## PR 포인트

## 고민과 학습내용

## 스크린샷
