### PR TITLE
[Feat] terra 요청 횟수 관리 api, terra 연동 해제 api 구현

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationApi.java
@@ -4,6 +4,7 @@ import com.ridingmate.api_server.domain.activity.dto.request.IntegrationProvider
 import com.ridingmate.api_server.domain.activity.dto.response.IntegrationAuthenticateResponse;
 import com.ridingmate.api_server.domain.activity.dto.response.IntegrationProviderAuthResponse;
 import com.ridingmate.api_server.domain.activity.dto.response.TerraAuthTokenResponse;
+import com.ridingmate.api_server.domain.activity.dto.response.ApiUsageResponse;
 import com.ridingmate.api_server.domain.auth.security.AuthUser;
 import com.ridingmate.api_server.global.exception.CommonResponse;
 import com.ridingmate.api_server.infra.terra.TerraProvider;
@@ -91,4 +92,22 @@ public interface IntegrationApi {
             @ApiResponse(responseCode = "500", description = "Terra API 호출 실패 - 서버 내부 오류")
     })
     ResponseEntity<CommonResponse<TerraAuthTokenResponse>> getTerraAuthToken(@AuthenticationPrincipal AuthUser authUser);
+
+    @Operation(
+            summary = "API 사용량 조회",
+            description = """
+                    현재 사용자의 이번달 API 사용량을 조회합니다.
+                    
+                    - **현재 사용량**: 이번달 사용한 API 호출 횟수
+                    - **월별 제한**: 30회 (운동 기록 동기화만 제한)
+                    - **남은 사용량**: 사용 가능한 횟수
+                    - **사용률**: 현재 사용량의 비율
+                    - **제한 초과 여부**: 제한을 초과했는지 여부
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공: API 사용량 조회 완료"),
+            @ApiResponse(responseCode = "401", description = "인증 실패 - 유효하지 않은 토큰"),
+    })
+    ResponseEntity<CommonResponse<ApiUsageResponse>> getApiUsage(@AuthenticationPrincipal AuthUser authUser);
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationApi.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -124,4 +125,26 @@ public interface IntegrationApi {
             @ApiResponse(responseCode = "429", description = "API 사용량 제한 초과 - 월별 제한(30회) 초과")
     })
     ResponseEntity<CommonResponse<ApiUsageIncrementResponse>> incrementApiUsage(@AuthenticationPrincipal AuthUser authUser);
+
+    @Operation(
+            summary = "특정 제공자 연동 해제",
+            description = """
+                    특정 서비스 제공자(Samsung Health, Apple Health 등)와의 연동을 해제합니다.
+                    
+                    - **제공자 지정**: path variable로 제공자 이름 지정
+                    - **연동 해제**: Terra API를 통한 실제 연동 해제
+                    - **로컬 비활성화**: DB에서 isActive를 false로 설정
+                    - **복구 불가**: 연동 해제 후 재연동 필요
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공: 제공자 연동 해제 완료"),
+            @ApiResponse(responseCode = "401", description = "인증 실패 - 유효하지 않은 토큰"),
+            @ApiResponse(responseCode = "404", description = "연동된 제공자를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "Terra API 호출 실패 - 서버 내부 오류")
+    })
+    ResponseEntity<CommonResponse<Void>> disconnectProvider(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable String providerName
+    );
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationApi.java
@@ -1,10 +1,7 @@
 package com.ridingmate.api_server.domain.activity.controller;
 
 import com.ridingmate.api_server.domain.activity.dto.request.IntegrationProviderAuthRequest;
-import com.ridingmate.api_server.domain.activity.dto.response.IntegrationAuthenticateResponse;
-import com.ridingmate.api_server.domain.activity.dto.response.IntegrationProviderAuthResponse;
-import com.ridingmate.api_server.domain.activity.dto.response.TerraAuthTokenResponse;
-import com.ridingmate.api_server.domain.activity.dto.response.ApiUsageResponse;
+import com.ridingmate.api_server.domain.activity.dto.response.*;
 import com.ridingmate.api_server.domain.auth.security.AuthUser;
 import com.ridingmate.api_server.global.exception.CommonResponse;
 import com.ridingmate.api_server.infra.terra.TerraProvider;
@@ -110,4 +107,21 @@ public interface IntegrationApi {
             @ApiResponse(responseCode = "401", description = "인증 실패 - 유효하지 않은 토큰"),
     })
     ResponseEntity<CommonResponse<ApiUsageResponse>> getApiUsage(@AuthenticationPrincipal AuthUser authUser);
+
+    @Operation(
+            summary = "API 사용량 증가",
+            description = """
+                    현재 사용자의 API 사용량을 1회 증가시킵니다.
+                    
+                    - **월별 제한**: 30회 (운동 기록 동기화만 제한)
+                    - **제한 초과 시**: HTTP 429 (Too Many Requests) 에러 발생
+                    - **사용 목적**: Terra API 호출 시 사용량 추적
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공: API 사용량 증가 완료"),
+            @ApiResponse(responseCode = "401", description = "인증 실패 - 유효하지 않은 토큰"),
+            @ApiResponse(responseCode = "429", description = "API 사용량 제한 초과 - 월별 제한(30회) 초과")
+    })
+    ResponseEntity<CommonResponse<ApiUsageIncrementResponse>> incrementApiUsage(@AuthenticationPrincipal AuthUser authUser);
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationController.java
@@ -4,6 +4,7 @@ import com.ridingmate.api_server.domain.activity.dto.request.IntegrationProvider
 import com.ridingmate.api_server.domain.activity.dto.response.IntegrationAuthenticateResponse;
 import com.ridingmate.api_server.domain.activity.dto.response.IntegrationProviderAuthResponse;
 import com.ridingmate.api_server.domain.activity.dto.response.TerraAuthTokenResponse;
+import com.ridingmate.api_server.domain.activity.dto.response.ApiUsageResponse;
 import com.ridingmate.api_server.domain.activity.exception.IntegrationSuccessCode;
 import com.ridingmate.api_server.domain.activity.facade.IntegrationFacade;
 import com.ridingmate.api_server.domain.auth.security.AuthUser;
@@ -76,5 +77,18 @@ public class IntegrationController implements IntegrationApi{
         return ResponseEntity
                 .status(IntegrationSuccessCode.INTEGRATION_TERRA_AUTH_TOKEN_SUCCESS.getStatus())
                 .body(CommonResponse.success(IntegrationSuccessCode.INTEGRATION_TERRA_AUTH_TOKEN_SUCCESS, response));
+    }
+
+    @Override
+    @GetMapping("/usage")
+    @ApiErrorCodeExample(UserErrorCode.class)
+    public ResponseEntity<CommonResponse<ApiUsageResponse>> getApiUsage(
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        ApiUsageResponse response = integrationFacade.getCurrentMonthUsage(authUser);
+        
+        return ResponseEntity
+                .status(IntegrationSuccessCode.INTEGRATION_API_USAGE_SUCCESS.getStatus())
+                .body(CommonResponse.success(IntegrationSuccessCode.INTEGRATION_API_USAGE_SUCCESS, response));
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationController.java
@@ -103,4 +103,19 @@ public class IntegrationController implements IntegrationApi{
                 .status(IntegrationSuccessCode.INTEGRATION_API_USAGE_INCREMENT_SUCCESS.getStatus())
                 .body(CommonResponse.success(IntegrationSuccessCode.INTEGRATION_API_USAGE_INCREMENT_SUCCESS, response));
     }
+
+    @Override
+    @DeleteMapping("/provider/{providerName}")
+    @ApiErrorCodeExample(UserErrorCode.class)
+    @ApiErrorCodeExample(TerraErrorCode.class)
+    public ResponseEntity<CommonResponse<Void>> disconnectProvider(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable String providerName
+    ) {
+        integrationFacade.disconnectProvider(authUser, providerName);
+        
+        return ResponseEntity
+                .status(IntegrationSuccessCode.INTEGRATION_PROVIDER_DISCONNECT_SUCCESS.getStatus())
+                .body(CommonResponse.success(IntegrationSuccessCode.INTEGRATION_PROVIDER_DISCONNECT_SUCCESS));
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationController.java
@@ -1,11 +1,9 @@
 package com.ridingmate.api_server.domain.activity.controller;
 
 import com.ridingmate.api_server.domain.activity.dto.request.IntegrationProviderAuthRequest;
-import com.ridingmate.api_server.domain.activity.dto.response.IntegrationAuthenticateResponse;
-import com.ridingmate.api_server.domain.activity.dto.response.IntegrationProviderAuthResponse;
-import com.ridingmate.api_server.domain.activity.dto.response.TerraAuthTokenResponse;
-import com.ridingmate.api_server.domain.activity.dto.response.ApiUsageResponse;
+import com.ridingmate.api_server.domain.activity.dto.response.*;
 import com.ridingmate.api_server.domain.activity.exception.IntegrationSuccessCode;
+import com.ridingmate.api_server.domain.activity.exception.code.ApiUsageErrorCode;
 import com.ridingmate.api_server.domain.activity.facade.IntegrationFacade;
 import com.ridingmate.api_server.domain.auth.security.AuthUser;
 import com.ridingmate.api_server.domain.user.exception.UserErrorCode;
@@ -90,5 +88,19 @@ public class IntegrationController implements IntegrationApi{
         return ResponseEntity
                 .status(IntegrationSuccessCode.INTEGRATION_API_USAGE_SUCCESS.getStatus())
                 .body(CommonResponse.success(IntegrationSuccessCode.INTEGRATION_API_USAGE_SUCCESS, response));
+    }
+
+    @Override
+    @PostMapping("/usage/increment")
+    @ApiErrorCodeExample(UserErrorCode.class)
+    @ApiErrorCodeExample(ApiUsageErrorCode.class)
+    public ResponseEntity<CommonResponse<ApiUsageIncrementResponse>> incrementApiUsage(
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        ApiUsageIncrementResponse response = integrationFacade.incrementApiUsageWithResponse(authUser);
+        
+        return ResponseEntity
+                .status(IntegrationSuccessCode.INTEGRATION_API_USAGE_INCREMENT_SUCCESS.getStatus())
+                .body(CommonResponse.success(IntegrationSuccessCode.INTEGRATION_API_USAGE_INCREMENT_SUCCESS, response));
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/request/AppleWorkoutImportRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/request/AppleWorkoutImportRequest.java
@@ -26,11 +26,9 @@ public record AppleWorkoutImportRequest(
         LocalDateTime endTime,
 
         @Schema(description = "운동 소요 시간 (초)", example = "3600")
-        @Positive(message = "운동 소요 시간은 양수여야 합니다.")
         Long duration,
 
         @Schema(description = "운동 거리 (미터)", example = "15000.0")
-        @Positive(message = "운동 거리는 양수여야 합니다.")
         Double distance,
 
         @Schema(description = "소모 칼로리", example = "450.0")

--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ApiUsageIncrementResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ApiUsageIncrementResponse.java
@@ -1,0 +1,42 @@
+package com.ridingmate.api_server.domain.activity.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+/**
+ * API 사용량 증가 응답 DTO
+ */
+public record ApiUsageIncrementResponse(
+        @Schema(description = "현재 시간", example = "2024-01-15T10:30:00")
+        LocalDateTime currentTime,
+
+        @Schema(description = "증가된 사용량", example = "16")
+        Integer currentUsage,
+
+        @Schema(description = "월별 제한", example = "30")
+        Integer monthlyLimit,
+
+        @Schema(description = "남은 사용량", example = "14")
+        Integer remainingUsage,
+
+        @Schema(description = "제한 초과 여부", example = "false")
+        Boolean isExceeded
+) {
+    /**
+     * 사용량 정보로부터 응답 생성
+     */
+    public static ApiUsageIncrementResponse of(Integer currentUsage, Integer monthlyLimit) {
+        LocalDateTime currentTime = LocalDateTime.now();
+        Integer remainingUsage = Math.max(0, monthlyLimit - currentUsage);
+        Boolean isExceeded = currentUsage >= monthlyLimit;
+
+        return new ApiUsageIncrementResponse(
+                currentTime,
+                currentUsage,
+                monthlyLimit,
+                remainingUsage,
+                isExceeded
+        );
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ApiUsageResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ApiUsageResponse.java
@@ -1,0 +1,35 @@
+package com.ridingmate.api_server.domain.activity.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * API 사용량 조회 응답 DTO
+ */
+public record ApiUsageResponse(
+        @Schema(description = "현재 월 총 사용량", example = "15")
+        Integer currentUsage,
+
+        @Schema(description = "월별 제한", example = "30")
+        Integer monthlyLimit,
+
+        @Schema(description = "남은 사용량", example = "15")
+        Integer remainingUsage,
+
+        @Schema(description = "제한 초과 여부", example = "false")
+        Boolean isExceeded
+) {
+    /**
+     * 사용량 정보로부터 응답 생성
+     */
+    public static ApiUsageResponse of(Integer currentUsage, Integer monthlyLimit) {
+        Integer remainingUsage = Math.max(0, monthlyLimit - currentUsage);
+        Boolean isExceeded = currentUsage >= monthlyLimit;
+
+        return new ApiUsageResponse(
+                currentUsage,
+                monthlyLimit,
+                remainingUsage,
+                isExceeded
+        );
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ApiUsageResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ApiUsageResponse.java
@@ -2,6 +2,8 @@ package com.ridingmate.api_server.domain.activity.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 /**
  * API 사용량 조회 응답 DTO
  */
@@ -16,12 +18,17 @@ public record ApiUsageResponse(
         Integer remainingUsage,
 
         @Schema(description = "제한 초과 여부", example = "false")
-        Boolean isExceeded
+        Boolean isExceeded,
+
+        @Schema(description = "제공자 별 마지막 갱신 일자")
+        List<ProviderSyncInfo> providerSyncInfos
 ) {
+
+
     /**
-     * 사용량 정보로부터 응답 생성
+     * 사용량 정보와 제공자 정보로부터 응답 생성
      */
-    public static ApiUsageResponse of(Integer currentUsage, Integer monthlyLimit) {
+    public static ApiUsageResponse of(Integer currentUsage, Integer monthlyLimit, List<ProviderSyncInfo> providerSyncInfos) {
         Integer remainingUsage = Math.max(0, monthlyLimit - currentUsage);
         Boolean isExceeded = currentUsage >= monthlyLimit;
 
@@ -29,7 +36,9 @@ public record ApiUsageResponse(
                 currentUsage,
                 monthlyLimit,
                 remainingUsage,
-                isExceeded
+                isExceeded,
+                providerSyncInfos
         );
     }
+
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ProviderSyncInfo.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ProviderSyncInfo.java
@@ -1,0 +1,25 @@
+package com.ridingmate.api_server.domain.activity.dto.response;
+
+import com.ridingmate.api_server.domain.user.entity.TerraUser;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record ProviderSyncInfo(
+        @Schema(description = "제공자 이름", example = "Samsung Health")
+        String providerName,
+
+        @Schema(description = "마지막 동기화 일시", example = "2024-01-15T10:30:00")
+        LocalDateTime lastSyncAt,
+
+        @Schema(description = "활성 상태", example = "true")
+        Boolean isActive
+) {
+    public static ProviderSyncInfo from(TerraUser terraUser){
+        return new ProviderSyncInfo(
+                terraUser.getProvider().toString(),
+                terraUser.getLastSyncDate(),
+                terraUser.isActive()
+        );
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/UserApiUsage.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/UserApiUsage.java
@@ -1,0 +1,52 @@
+package com.ridingmate.api_server.domain.activity.entity;
+
+import com.ridingmate.api_server.domain.user.entity.User;
+import com.ridingmate.api_server.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자 API 사용량 추적 엔티티
+ */
+@Entity
+@Table(name = "user_api_usage", 
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "year", "month"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserApiUsage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "year", nullable = false)
+    private int year;
+
+    @Column(name = "month", nullable = false)
+    private int month;
+
+    @Column(name = "activity_sync_count", nullable = false)
+    private int activitySyncCount = 0;
+
+    @Builder
+    public UserApiUsage(User user, Integer year, Integer month, int activitySyncCount) {
+        this.user = user;
+        this.year = year;
+        this.month = month;
+        this.activitySyncCount = activitySyncCount;
+    }
+
+    /**
+     * 활동 동기화 횟수 증가
+     */
+    public void incrementActivitySync() {
+        this.activitySyncCount++;
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/activity/exception/ApiUsageLimitExceededException.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/exception/ApiUsageLimitExceededException.java
@@ -1,0 +1,14 @@
+package com.ridingmate.api_server.domain.activity.exception;
+
+import com.ridingmate.api_server.domain.activity.exception.code.ApiUsageErrorCode;
+import com.ridingmate.api_server.global.exception.BusinessException;
+
+/**
+ * API 사용량 제한 초과 예외
+ */
+public class ApiUsageLimitExceededException extends BusinessException {
+    
+    public ApiUsageLimitExceededException() {
+        super(ApiUsageErrorCode.API_USAGE_LIMIT_EXCEEDED);
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/activity/exception/ApiUsageLimitExceededException.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/exception/ApiUsageLimitExceededException.java
@@ -8,7 +8,7 @@ import com.ridingmate.api_server.global.exception.BusinessException;
  */
 public class ApiUsageLimitExceededException extends BusinessException {
     
-    public ApiUsageLimitExceededException() {
-        super(ApiUsageErrorCode.API_USAGE_LIMIT_EXCEEDED);
+    public ApiUsageLimitExceededException(ApiUsageErrorCode errorCode) {
+        super(errorCode);
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/exception/IntegrationSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/exception/IntegrationSuccessCode.java
@@ -11,7 +11,8 @@ public enum IntegrationSuccessCode implements SuccessCode {
     INTEGRATION_AUTHENTICATION_SUCCESS(HttpStatus.OK, "기록 연동을 위한 인증 링크 생성이 완료되었습니다."),
     INTEGRATION_RETRIEVE_ACTIVITY_SUCCESS(HttpStatus.ACCEPTED, "기록 연동 요청이 완료되었습니다."),
     INTEGRATION_TERRA_AUTH_TOKEN_SUCCESS(HttpStatus.OK, "Terra SDK 인증 토큰이 발급되었습니다."),
-    INTEGRATION_API_USAGE_SUCCESS(HttpStatus.OK, "API 사용량 조회가 완료되었습니다.")
+    INTEGRATION_API_USAGE_SUCCESS(HttpStatus.OK, "API 사용량 조회가 완료되었습니다."),
+    INTEGRATION_API_USAGE_INCREMENT_SUCCESS(HttpStatus.OK, "API 사용량이 증가되었습니다.")
     ;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ridingmate/api_server/domain/activity/exception/IntegrationSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/exception/IntegrationSuccessCode.java
@@ -12,7 +12,8 @@ public enum IntegrationSuccessCode implements SuccessCode {
     INTEGRATION_RETRIEVE_ACTIVITY_SUCCESS(HttpStatus.ACCEPTED, "기록 연동 요청이 완료되었습니다."),
     INTEGRATION_TERRA_AUTH_TOKEN_SUCCESS(HttpStatus.OK, "Terra SDK 인증 토큰이 발급되었습니다."),
     INTEGRATION_API_USAGE_SUCCESS(HttpStatus.OK, "API 사용량 조회가 완료되었습니다."),
-    INTEGRATION_API_USAGE_INCREMENT_SUCCESS(HttpStatus.OK, "API 사용량이 증가되었습니다.")
+    INTEGRATION_API_USAGE_INCREMENT_SUCCESS(HttpStatus.OK, "API 사용량이 증가되었습니다."),
+    INTEGRATION_PROVIDER_DISCONNECT_SUCCESS(HttpStatus.OK, "제공자 연동이 해제되었습니다.")
     ;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ridingmate/api_server/domain/activity/exception/IntegrationSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/exception/IntegrationSuccessCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum IntegrationSuccessCode implements SuccessCode {
     INTEGRATION_AUTHENTICATION_SUCCESS(HttpStatus.OK, "기록 연동을 위한 인증 링크 생성이 완료되었습니다."),
     INTEGRATION_RETRIEVE_ACTIVITY_SUCCESS(HttpStatus.ACCEPTED, "기록 연동 요청이 완료되었습니다."),
-    INTEGRATION_TERRA_AUTH_TOKEN_SUCCESS(HttpStatus.OK, "Terra SDK 인증 토큰이 발급되었습니다.")
+    INTEGRATION_TERRA_AUTH_TOKEN_SUCCESS(HttpStatus.OK, "Terra SDK 인증 토큰이 발급되었습니다."),
+    INTEGRATION_API_USAGE_SUCCESS(HttpStatus.OK, "API 사용량 조회가 완료되었습니다.")
     ;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ridingmate/api_server/domain/activity/exception/code/ApiUsageErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/exception/code/ApiUsageErrorCode.java
@@ -1,0 +1,20 @@
+package com.ridingmate.api_server.domain.activity.exception.code;
+
+import com.ridingmate.api_server.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * API 사용량 관련 에러 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ApiUsageErrorCode implements ErrorCode {
+    API_USAGE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "API_USAGE_LIMIT_EXCEEDED","API 사용량 제한을 초과했습니다. 월별 제한: 30회"),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+    private final String code;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/activity/facade/IntegrationFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/facade/IntegrationFacade.java
@@ -153,4 +153,18 @@ public class IntegrationFacade {
         
         return response;
     }
+
+    /**
+     * 특정 제공자 연동 해제
+     * @param authUser 인증된 사용자
+     * @param providerName 제공자 이름
+     */
+    public void disconnectProvider(AuthUser authUser, String providerName) {
+        log.info("특정 제공자 연동 해제: userId={}, providerName={}", authUser.id(), providerName);
+        
+        User user = userService.getUser(authUser.id());
+        terraUserService.disconnectProvider(user, providerName);
+        
+        log.info("특정 제공자 연동 해제 완료: userId={}, providerName={}", authUser.id(), providerName);
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/facade/IntegrationFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/facade/IntegrationFacade.java
@@ -118,4 +118,39 @@ public class IntegrationFacade {
         
         return ApiUsageResponse.of(usage.getActivitySyncCount(), limit, providerSyncInfos);
     }
+
+    /**
+     * API 사용량 1회 증가
+     * @param authUser 인증된 사용자
+     */
+    public void incrementApiUsage(AuthUser authUser) {
+        log.info("API 사용량 증가: userId={}", authUser.id());
+        
+        User user = userService.getUser(authUser.id());
+        userApiUsageService.incrementApiUsage(user);
+        
+        log.info("API 사용량 증가 완료: userId={}", authUser.id());
+    }
+
+    /**
+     * API 사용량 1회 증가 (응답 포함)
+     * @param authUser 인증된 사용자
+     * @return 증가된 사용량 정보
+     */
+    public ApiUsageIncrementResponse incrementApiUsageWithResponse(AuthUser authUser) {
+        log.info("API 사용량 증가 (응답 포함): userId={}", authUser.id());
+        
+        User user = userService.getUser(authUser.id());
+        UserApiUsage usage = userApiUsageService.incrementApiUsageWithResponse(user);
+        int limit = userApiUsageService.getMonthlyLimit();
+        ApiUsageIncrementResponse response = ApiUsageIncrementResponse.of(
+                usage.getActivitySyncCount(),
+                limit
+        );
+        
+        log.info("API 사용량 증가 완료 (응답 포함): userId={}, currentUsage={}, remaining={}", 
+                authUser.id(), response.currentUsage(), response.remainingUsage());
+        
+        return response;
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/repository/UserApiUsageRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/repository/UserApiUsageRepository.java
@@ -1,0 +1,51 @@
+package com.ridingmate.api_server.domain.activity.repository;
+
+import com.ridingmate.api_server.domain.activity.entity.UserApiUsage;
+import com.ridingmate.api_server.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+/**
+ * 사용자 API 사용량 레포지토리
+ */
+@Repository
+public interface UserApiUsageRepository extends JpaRepository<UserApiUsage, Long> {
+
+    /**
+     * 특정 사용자의 현재 월 사용량 조회
+     */
+    @Query("SELECT u FROM UserApiUsage u WHERE u.user = :user AND u.year = :year AND u.month = :month")
+    Optional<UserApiUsage> findByUserAndCurrentMonth(@Param("user") User user, 
+                                                   @Param("year") Integer year, 
+                                                   @Param("month") Integer month);
+
+    /**
+     * 특정 사용자의 현재 월 사용량 조회 (LocalDate 사용)
+     */
+    default Optional<UserApiUsage> findByUserAndCurrentMonth(User user) {
+        LocalDate now = LocalDate.now();
+        return findByUserAndCurrentMonth(user, now.getYear(), now.getMonthValue());
+    }
+
+    /**
+     * 특정 사용자의 현재 월 총 사용량 조회
+     */
+    @Query("SELECT COALESCE(SUM(u.activitySyncCount), 0) FROM UserApiUsage u WHERE u.user = :user AND u.year = :year AND u.month = :month")
+    int getTotalUsageForCurrentMonth(@Param("user") User user,
+                                       @Param("year") Integer year, 
+                                       @Param("month") Integer month);
+
+    /**
+     * 특정 사용자의 현재 월 총 사용량 조회 (LocalDate 사용)
+     */
+    default int getTotalUsageForCurrentMonth(User user) {
+        LocalDate now = LocalDate.now();
+        return getTotalUsageForCurrentMonth(user, now.getYear(), now.getMonthValue());
+    }
+
+}

--- a/src/main/java/com/ridingmate/api_server/domain/activity/service/TerraService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/service/TerraService.java
@@ -32,7 +32,7 @@ public class TerraService {
     }
 
     public List<TerraUser> getTerraUsers(User user){
-        return terraUserRepository.findAllByUserAndIsActiveTrue(user);
+        return terraUserRepository.findAllByUserAndIsActiveTrueAndDeletedAtIsNull(user);
     }
 
     @Transactional

--- a/src/main/java/com/ridingmate/api_server/domain/activity/service/TerraWebhookProcessingService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/service/TerraWebhookProcessingService.java
@@ -48,7 +48,7 @@ public class TerraWebhookProcessingService {
             return;
         }
 
-        TerraUser terraUser = terraUserRepository.findByTerraUserId(UUID.fromString(user.userId()))
+        TerraUser terraUser = terraUserRepository.findByTerraUserIdAndIsActiveTrueAndDeletedAtIsNull(UUID.fromString(user.userId()))
                 .orElseThrow(() -> new TerraUserException(TerraUserErrorCode.TERRA_USER_NOT_FOUND));
 
         terraUser.setActive();

--- a/src/main/java/com/ridingmate/api_server/domain/activity/service/UserApiUsageService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/service/UserApiUsageService.java
@@ -1,0 +1,53 @@
+package com.ridingmate.api_server.domain.activity.service;
+
+import com.ridingmate.api_server.domain.activity.entity.UserApiUsage;
+import com.ridingmate.api_server.domain.activity.repository.UserApiUsageRepository;
+import com.ridingmate.api_server.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+/**
+ * 사용자 API 사용량 관리 서비스
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserApiUsageService {
+
+    private final UserApiUsageRepository userApiUsageRepository;
+    
+    private static final int MONTHLY_LIMIT = 30;
+
+    /**
+     * 현재 월 사용량 조회 또는 생성
+     * @param user 사용자
+     * @return 현재 월 사용량 정보
+     */
+    public UserApiUsage getOrCreateCurrentMonthUsage(User user) {
+        return userApiUsageRepository.findByUserAndCurrentMonth(user)
+                .orElseGet(() -> {
+                    UserApiUsage newUsage = createForCurrentMonth(user);
+                    return userApiUsageRepository.save(newUsage);
+                });
+    }
+
+    /**
+     * 현재 년월로 UserApiUsage 생성
+     */
+    public UserApiUsage createForCurrentMonth(User user) {
+        LocalDate now = LocalDate.now();
+        return UserApiUsage.builder()
+                .user(user)
+                .year(now.getYear())
+                .month(now.getMonthValue())
+                .activitySyncCount(0)
+                .build();
+    }
+
+    public int getMonthlyLimit(){
+        return MONTHLY_LIMIT;
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/entity/TerraUser.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/entity/TerraUser.java
@@ -12,9 +12,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = "terra_users", uniqueConstraints = {
-        @UniqueConstraint(name = "user_provider", columnNames = {"user_id", "provider"})
-})
+@Table(name = "terra_users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TerraUser extends BaseTimeEntity {
@@ -37,8 +35,11 @@ public class TerraUser extends BaseTimeEntity {
     @Column
     private LocalDateTime lastSyncDate;
 
-    @Column(nullable = false)
+    @Column(name = "is_active", nullable = false)
     private boolean isActive = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;  // ← 연동 해제 시간
 
     @Builder
     public TerraUser(UUID terraUserId, TerraProvider provider, User user) {
@@ -56,6 +57,11 @@ public class TerraUser extends BaseTimeEntity {
     }
 
     public void setInactive(){
+        isActive = false;
+    }
+
+    public void delete() {
+        deletedAt = LocalDateTime.now();
         isActive = false;
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/repository/TerraUserRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/repository/TerraUserRepository.java
@@ -2,6 +2,7 @@ package com.ridingmate.api_server.domain.user.repository;
 
 import com.ridingmate.api_server.domain.user.entity.TerraUser;
 import com.ridingmate.api_server.domain.user.entity.User;
+import com.ridingmate.api_server.infra.terra.TerraProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,7 +13,9 @@ import java.util.UUID;
 @Repository
 public interface TerraUserRepository extends JpaRepository<TerraUser, Long> {
 
-    List<TerraUser> findAllByUserAndIsActiveTrue(User user);
+    List<TerraUser> findAllByUserAndIsActiveTrueAndDeletedAtIsNull(User user);
 
-    Optional<TerraUser> findByTerraUserId(UUID terraUserId);
+    Optional<TerraUser> findByUserAndProviderAndIsActiveTrueAndDeletedAtIsNull(User user, TerraProvider provider);
+
+    Optional<TerraUser> findByTerraUserIdAndIsActiveTrueAndDeletedAtIsNull(UUID terraUserId);
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/service/TerraUserService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/service/TerraUserService.java
@@ -109,4 +109,20 @@ public class TerraUserService {
             throw e; // 상위 메서드에서 처리하도록 예외 전파
         }
     }
+
+    /**
+     * 특정 사용자의 활성 Terra User 정보만 조회
+     * @param user 사용자
+     * @return 해당 사용자의 활성 Terra User 목록
+     */
+    @Transactional(readOnly = true)
+    public List<TerraUser> getActiveTerraUsers(User user) {
+        log.info("사용자 활성 Terra User 조회: userId={}", user.getId());
+        
+        List<TerraUser> activeTerraUsers = terraUserRepository.findAllByUserAndIsActiveTrue(user);
+        
+        log.info("사용자 활성 Terra User 조회 완료: userId={}, count={}", user.getId(), activeTerraUsers.size());
+        
+        return activeTerraUsers;
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/user/service/TerraUserService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/service/TerraUserService.java
@@ -50,7 +50,7 @@ public class TerraUserService {
         
         try {
             // 1. 사용자의 모든 활성 Terra 연동 조회
-            List<TerraUser> activeTerraUsers = terraUserRepository.findAllByUserAndIsActiveTrue(user);
+            List<TerraUser> activeTerraUsers = terraUserRepository.findAllByUserAndIsActiveTrueAndDeletedAtIsNull(user);
             
             // 2. Terra 연동 비활성화 처리
             deactivateTerraUsers(activeTerraUsers);
@@ -74,7 +74,7 @@ public class TerraUserService {
                 deactivateTerraConnection(terraUser);
                 
                 // 2. 로컬 DB에서 isActive를 false로 설정
-                terraUser.setInactive();
+                terraUser.delete();
                 
                 log.debug("Terra 연동 비활성화 완료: terraUserId={}, provider={}", 
                     terraUser.getTerraUserId(), terraUser.getProvider());
@@ -84,7 +84,7 @@ public class TerraUserService {
                     terraUser.getTerraUserId(), terraUser.getProvider(), e);
                 
                 // Terra 연동 해제 실패해도 로컬 DB는 비활성화
-                terraUser.setInactive();
+                terraUser.delete();
             }
         }
         
@@ -119,10 +119,46 @@ public class TerraUserService {
     public List<TerraUser> getActiveTerraUsers(User user) {
         log.info("사용자 활성 Terra User 조회: userId={}", user.getId());
         
-        List<TerraUser> activeTerraUsers = terraUserRepository.findAllByUserAndIsActiveTrue(user);
+        List<TerraUser> activeTerraUsers = terraUserRepository.findAllByUserAndIsActiveTrueAndDeletedAtIsNull(user);
         
         log.info("사용자 활성 Terra User 조회 완료: userId={}, count={}", user.getId(), activeTerraUsers.size());
         
         return activeTerraUsers;
+    }
+
+    /**
+     * 특정 제공자와의 연동 해제
+     * @param user 사용자
+     * @param providerName 제공자 이름 (SAMSUNG_HEALTH, APPLE_HEALTH 등)
+     * @throws UserException 연동된 제공자를 찾을 수 없을 때
+     */
+    @Transactional
+    public void disconnectProvider(User user, String providerName) {
+        log.info("특정 제공자 연동 해제 시작: userId={}, providerName={}", user.getId(), providerName);
+        
+        try {
+            // 1. 제공자 이름을 TerraProvider enum으로 변환
+            TerraProvider terraProvider = TerraProvider.fromProviderName(providerName);
+            
+            // 2. 해당 사용자의 특정 제공자 Terra User 조회
+            TerraUser terraUser = terraUserRepository.findByUserAndProviderAndIsActiveTrueAndDeletedAtIsNull(user, terraProvider)
+                    .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+            
+            // 3. Terra API를 통한 실제 연동 해제
+            deactivateTerraConnection(terraUser);
+            
+            // 4. 로컬 DB에서 isActive를 false로 설정
+            terraUser.delete();
+            
+            log.info("특정 제공자 연동 해제 완료: userId={}, providerName={}, terraUserId={}", 
+                    user.getId(), providerName, terraUser.getTerraUserId());
+                    
+        } catch (IllegalArgumentException e) {
+            log.error("잘못된 제공자 이름: userId={}, providerName={}", user.getId(), providerName, e);
+            throw new UserException(UserErrorCode.USER_NOT_FOUND);
+        } catch (Exception e) {
+            log.error("특정 제공자 연동 해제 실패: userId={}, providerName={}", user.getId(), providerName, e);
+            throw new UserException(UserErrorCode.USER_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/ridingmate/api_server/infra/terra/TerraProvider.java
+++ b/src/main/java/com/ridingmate/api_server/infra/terra/TerraProvider.java
@@ -8,7 +8,26 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Schema(description = "테라 지원 서비스 목록")
 public enum TerraProvider {
-    STRAVA,
-    GARMIN
+    STRAVA("STRAVA", "Strava"),
+    GARMIN("GARMIN", "Garmin")
     ;
+
+    private final String providerName;
+    private final String displayName;
+
+
+    /**
+     * 제공자 이름으로 TerraProvider 찾기
+     * @param providerName 제공자 이름
+     * @return TerraProvider
+     * @throws IllegalArgumentException 지원하지 않는 제공자 이름일 때
+     */
+    public static TerraProvider fromProviderName(String providerName) {
+        for (TerraProvider provider : values()) {
+            if (provider.providerName.equalsIgnoreCase(providerName)) {
+                return provider;
+            }
+        }
+        throw new IllegalArgumentException("지원하지 않는 제공자입니다: " + providerName);
+    }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용

1. API 사용량 조회 API [GET /api/integration/usage]
현재 사용자의 이번달 API 사용량 조회
현재 사용량, 월별 제한(30회), 남은 사용량, 제공자별 마지막 동기화 일시

2. API 사용량 증가 API [POST /api/integration/usage/increment]
API 사용량을 1회 증가 (월별 제한 체크 포함)
현재 시간, 증가된 사용량, 남은 사용량

3. 특정 제공자 연동 해제 API [DELETE /api/integration/provider/{providerName}]
특정 서비스 제공자(Strava, Garmin 등)와의 연동 해제
Terra API를 통한 실제 연동 해제 + 로컬 DB 비활성화

4. 애플 운동 기록 연동시 0도 받을 수 있도록 수정

## PR 포인트

현재 스트라바 연동에서 오류가 발생해서 실제 terra측 인증을 끊는 테스트가 원활히 되지 못했습니다 이 부분 확인 부탁드립니다.


## 고민과 학습내용

## 스크린샷
