### PR TITLE
[Feat] 애플 운동 기록 연동 횟수 관련 기능 추가 및 duration 관련 수정

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationApi.java
@@ -127,6 +127,31 @@ public interface IntegrationApi {
     ResponseEntity<CommonResponse<ApiUsageIncrementResponse>> incrementApiUsage(@AuthenticationPrincipal AuthUser authUser);
 
     @Operation(
+            summary = "Apple HealthKit 연동",
+            description = "Apple HealthKit과 연동하여 운동 데이터를 동기화할 수 있도록 설정합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공: Apple HealthKit 연동 완료"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 - 이미 연동된 상태"),
+            @ApiResponse(responseCode = "401", description = "인증 실패 - 유효하지 않은 토큰"),
+    })
+    ResponseEntity<CommonResponse<AppleConnectResponse>> connectApple(
+            @AuthenticationPrincipal AuthUser authUser
+    );
+
+    @Operation(
+            summary = "Apple HealthKit 연동 상태 조회",
+            description = "현재 Apple HealthKit 연동 상태와 마지막 동기화 시간을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공: Apple HealthKit 연동 상태 조회 완료"),
+            @ApiResponse(responseCode = "401", description = "인증 실패 - 유효하지 않은 토큰"),
+    })
+    ResponseEntity<CommonResponse<AppleStatusResponse>> getAppleStatus(
+            @AuthenticationPrincipal AuthUser authUser
+    );
+
+    @Operation(
             summary = "특정 제공자 연동 해제",
             description = """
                     특정 서비스 제공자(Samsung Health, Apple Health 등)와의 연동을 해제합니다.

--- a/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/controller/IntegrationController.java
@@ -6,6 +6,7 @@ import com.ridingmate.api_server.domain.activity.exception.IntegrationSuccessCod
 import com.ridingmate.api_server.domain.activity.exception.code.ApiUsageErrorCode;
 import com.ridingmate.api_server.domain.activity.facade.IntegrationFacade;
 import com.ridingmate.api_server.domain.auth.security.AuthUser;
+import com.ridingmate.api_server.domain.user.exception.AppleErrorCode;
 import com.ridingmate.api_server.domain.user.exception.UserErrorCode;
 import com.ridingmate.api_server.global.exception.ApiErrorCodeExample;
 import com.ridingmate.api_server.global.exception.CommonResponse;
@@ -102,6 +103,33 @@ public class IntegrationController implements IntegrationApi{
         return ResponseEntity
                 .status(IntegrationSuccessCode.INTEGRATION_API_USAGE_INCREMENT_SUCCESS.getStatus())
                 .body(CommonResponse.success(IntegrationSuccessCode.INTEGRATION_API_USAGE_INCREMENT_SUCCESS, response));
+    }
+
+    @Override
+    @PostMapping("/apple/connect")
+    @ApiErrorCodeExample(UserErrorCode.class)
+    @ApiErrorCodeExample(AppleErrorCode.class)
+    public ResponseEntity<CommonResponse<AppleConnectResponse>> connectApple(
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        AppleConnectResponse response = integrationFacade.connectApple(authUser);
+        
+        return ResponseEntity
+                .status(IntegrationSuccessCode.INTEGRATION_APPLE_CONNECT_SUCCESS.getStatus())
+                .body(CommonResponse.success(IntegrationSuccessCode.INTEGRATION_APPLE_CONNECT_SUCCESS, response));
+    }
+
+    @Override
+    @GetMapping("/apple/status")
+    @ApiErrorCodeExample(UserErrorCode.class)
+    public ResponseEntity<CommonResponse<AppleStatusResponse>> getAppleStatus(
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        AppleStatusResponse response = integrationFacade.getAppleStatus(authUser);
+        
+        return ResponseEntity
+                .status(IntegrationSuccessCode.INTEGRATION_APPLE_STATUS_SUCCESS.getStatus())
+                .body(CommonResponse.success(IntegrationSuccessCode.INTEGRATION_APPLE_STATUS_SUCCESS, response));
     }
 
     @Override

--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ActivityDetailResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ActivityDetailResponse.java
@@ -29,11 +29,11 @@ public record ActivityDetailResponse(
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime endedAt,
 
-        @Schema(description = "운동 시간 (분)", example = "14")
-        Long activeDurationMinutes,
+        @Schema(description = "운동 시간 (초)", example = "840")
+        Long activeDurationSeconds,
 
-        @Schema(description = "전체 시간 (분)", example = "20")
-        Long totalDurationMinutes,
+        @Schema(description = "전체 시간 (초)", example = "1200")
+        Long totalDurationSeconds,
 
         @Schema(description = "이동 거리 (km)", example = "3.14")
         Double distance,
@@ -171,8 +171,8 @@ public record ActivityDetailResponse(
         Duration activeDuration = activity.getDuration();
 
         // 평균 속도 계산 (km/h)
-        double averageSpeed = activeDuration.toMinutes() > 0 
-                ? (activity.getDistance() / 1000.0) / (activeDuration.toMinutes() / 60.0)
+        double averageSpeed = activeDuration.toSeconds() > 0 
+                ? (activity.getDistance() / 1000.0) / (activeDuration.toSeconds() / 3600.0)
                 : 0.0;
 
         // 사용자 정보 생성
@@ -183,8 +183,8 @@ public record ActivityDetailResponse(
                 activity.getTitle(),
                 activity.getStartedAt(),
                 activity.getEndedAt(),
-                activeDuration.toMinutes(),
-                totalDuration.toMinutes(),
+                activeDuration.toSeconds(),
+                totalDuration.toSeconds(),
                 activity.getDistance() / 1000.0, // 미터를 킬로미터로 변환
                 Math.round(averageSpeed * 100.0) / 100.0, // 소수점 2자리 반올림
                 activity.getElevationGain(),

--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ActivityListItemResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ActivityListItemResponse.java
@@ -23,7 +23,7 @@ public record ActivityListItemResponse(
         Double distance,
 
         @Schema(description = "소요 시간 (초)", example = "9000")
-        Long duration,
+        Long durationSeconds,
 
         @Schema(description = "상승 고도 (m)", example = "150.0")
         Double elevationGain,

--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ActivityStatsResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ActivityStatsResponse.java
@@ -44,7 +44,7 @@ public record ActivityStatsResponse(
             Double totalElevationGain,
 
             @Schema(description = "총 운동 시간 (초)", example = "10860")
-            Long totalDuration,
+            Long totalDurationSeconds,
 
             @Schema(description = "총 활동 횟수", example = "3")
             Integer totalActivityCount
@@ -68,7 +68,7 @@ public record ActivityStatsResponse(
             Double elevationGainM,
 
             @Schema(description = "운동 시간 (초)", example = "3600")
-            Long durationSec
+            Long durationSeconds
     ) {}
 
     /**

--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/AppleConnectResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/AppleConnectResponse.java
@@ -1,0 +1,31 @@
+package com.ridingmate.api_server.domain.activity.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+/**
+ * Apple HealthKit 연동 응답 DTO
+ */
+public record AppleConnectResponse(
+        @Schema(description = "연동 성공 여부", example = "true")
+        Boolean isConnected,
+
+        @Schema(description = "연동 일시", example = "2024-01-15T10:30:00")
+        LocalDateTime connectedAt,
+
+        @Schema(description = "마지막 동기화 일시", example = "2024-01-15T10:30:00")
+        LocalDateTime lastSyncAt,
+
+        @Schema(description = "연동 상태 메시지", example = "Apple HealthKit이 성공적으로 연동되었습니다.")
+        String message
+) {
+    public static AppleConnectResponse from(com.ridingmate.api_server.domain.user.entity.AppleUser appleUser) {
+        return new AppleConnectResponse(
+                appleUser.isActive(),
+                appleUser.getCreatedAt(),
+                appleUser.getLastSyncDate(),
+                "Apple HealthKit이 성공적으로 연동되었습니다."
+        );
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/AppleStatusResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/AppleStatusResponse.java
@@ -1,0 +1,41 @@
+package com.ridingmate.api_server.domain.activity.dto.response;
+
+import com.ridingmate.api_server.domain.user.entity.AppleUser;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+/**
+ * Apple HealthKit 연동 상태 조회 응답 DTO
+ */
+public record AppleStatusResponse(
+        @Schema(description = "연동 여부", example = "true")
+        Boolean isConnected,
+
+        @Schema(description = "연동 일시", example = "2024-01-15T10:30:00")
+        LocalDateTime connectedAt,
+
+        @Schema(description = "마지막 동기화 일시", example = "2024-01-15T10:30:00")
+        LocalDateTime lastSyncAt,
+
+        @Schema(description = "연동 상태 메시지", example = "Apple HealthKit이 연동되어 있습니다.")
+        String message
+) {
+    public static AppleStatusResponse from(AppleUser appleUser) {
+        return new AppleStatusResponse(
+                appleUser.isActive(),
+                appleUser.getCreatedAt(),
+                appleUser.getLastSyncDate(),
+                "Apple HealthKit이 연동되어 있습니다."
+        );
+    }
+
+    public static AppleStatusResponse notConnected() {
+        return new AppleStatusResponse(
+                false,
+                null,
+                null,
+                "Apple HealthKit이 연동되어 있지 않습니다."
+        );
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ProviderSyncInfo.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ProviderSyncInfo.java
@@ -1,5 +1,6 @@
 package com.ridingmate.api_server.domain.activity.dto.response;
 
+import com.ridingmate.api_server.domain.user.entity.AppleUser;
 import com.ridingmate.api_server.domain.user.entity.TerraUser;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -20,6 +21,14 @@ public record ProviderSyncInfo(
                 terraUser.getProvider().toString(),
                 terraUser.getLastSyncDate(),
                 terraUser.isActive()
+        );
+    }
+
+    public static ProviderSyncInfo fromAppleUser(AppleUser appleUser){
+        return new ProviderSyncInfo(
+                "Apple HealthKit",
+                appleUser.getLastSyncDate(),
+                appleUser.isActive()
         );
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/exception/IntegrationSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/exception/IntegrationSuccessCode.java
@@ -13,6 +13,8 @@ public enum IntegrationSuccessCode implements SuccessCode {
     INTEGRATION_TERRA_AUTH_TOKEN_SUCCESS(HttpStatus.OK, "Terra SDK 인증 토큰이 발급되었습니다."),
     INTEGRATION_API_USAGE_SUCCESS(HttpStatus.OK, "API 사용량 조회가 완료되었습니다."),
     INTEGRATION_API_USAGE_INCREMENT_SUCCESS(HttpStatus.OK, "API 사용량이 증가되었습니다."),
+    INTEGRATION_APPLE_CONNECT_SUCCESS(HttpStatus.OK, "Apple HealthKit 연동이 완료되었습니다."),
+    INTEGRATION_APPLE_STATUS_SUCCESS(HttpStatus.OK, "Apple HealthKit 연동 상태 조회가 완료되었습니다."),
     INTEGRATION_PROVIDER_DISCONNECT_SUCCESS(HttpStatus.OK, "제공자 연동이 해제되었습니다.")
     ;
     private final HttpStatus status;

--- a/src/main/java/com/ridingmate/api_server/domain/activity/facade/ActivityFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/facade/ActivityFacade.java
@@ -280,7 +280,7 @@ public class ActivityFacade {
             }
         }
 
-        AppleUser appleUser = appleUserService.getOrCreateAppleUser(user);
+        AppleUser appleUser = appleUserService.getAppleUser(user);
         appleUserService.updateLastSyncDate(appleUser);
 
         

--- a/src/main/java/com/ridingmate/api_server/domain/activity/facade/IntegrationFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/facade/IntegrationFacade.java
@@ -176,9 +176,18 @@ public class IntegrationFacade {
      */
     public void disconnectProvider(AuthUser authUser, String providerName) {
         log.info("특정 제공자 연동 해제: userId={}, providerName={}", authUser.id(), providerName);
-        
+
         User user = userService.getUser(authUser.id());
-        terraUserService.disconnectProvider(user, providerName);
+        
+        // Apple HealthKit 연동 해제
+        if ("APPLE-HEALTH".equalsIgnoreCase(providerName) || "APPLE-HEALTH-KIT".equalsIgnoreCase(providerName)) {
+            appleUserService.disconnectAppleUser(user);
+            log.info("Apple HealthKit 연동 해제 완료: userId={}", authUser.id());
+        } else {
+            // Terra 연동 해제 (Samsung Health, Google Fit 등)
+            terraUserService.disconnectProvider(user, providerName);
+            log.info("Terra 제공자 연동 해제 완료: userId={}, providerName={}", authUser.id(), providerName);
+        }
         
         log.info("특정 제공자 연동 해제 완료: userId={}, providerName={}", authUser.id(), providerName);
     }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/facade/IntegrationFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/facade/IntegrationFacade.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -165,6 +166,46 @@ public class IntegrationFacade {
         
         log.info("API 사용량 증가 완료 (응답 포함): userId={}, currentUsage={}, remaining={}", 
                 authUser.id(), response.currentUsage(), response.remainingUsage());
+        
+        return response;
+    }
+
+    /**
+     * Apple HealthKit 연동
+     * @param authUser 인증된 사용자
+     * @return Apple 연동 응답
+     */
+    public AppleConnectResponse connectApple(AuthUser authUser) {
+        log.info("Apple HealthKit 연동: userId={}", authUser.id());
+        
+        User user = userService.getUser(authUser.id());
+        AppleUser appleUser = appleUserService.createAppleUser(user);
+        
+        AppleConnectResponse response = AppleConnectResponse.from(appleUser);
+        
+        log.info("Apple HealthKit 연동 완료: userId={}, connectedAt={}", 
+                authUser.id(), appleUser.getCreatedAt());
+        
+        return response;
+    }
+
+    /**
+     * Apple HealthKit 연동 상태 조회
+     * @param authUser 인증된 사용자
+     * @return Apple 연동 상태 응답
+     */
+    public AppleStatusResponse getAppleStatus(AuthUser authUser) {
+        log.info("Apple HealthKit 연동 상태 조회: userId={}", authUser.id());
+        
+        User user = userService.getUser(authUser.id());
+        Optional<AppleUser> appleUser = appleUserService.getActiveAppleUser(user);
+        
+        AppleStatusResponse response = appleUser.isPresent() 
+                ? AppleStatusResponse.from(appleUser.get())
+                : AppleStatusResponse.notConnected();
+        
+        log.info("Apple HealthKit 연동 상태 조회 완료: userId={}, isConnected={}", 
+                authUser.id(), response.isConnected());
         
         return response;
     }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/service/ActivityService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/service/ActivityService.java
@@ -757,16 +757,13 @@ public class ActivityService {
 
     /**
      * Apple HealthKit 운동 기록 업로드
-     * @param userId 사용자 ID
+     * @param user 사용자
      * @param request Apple 운동 기록 업로드 요청
      * @return 업로드된 운동 기록 목록
      */
     @Transactional
-    public AppleWorkoutsImportResponse importAppleWorkouts(Long userId, AppleWorkoutsImportRequest request) {
-        log.info("Apple 운동 기록 업로드 시작: userId={}, count={}", userId, request.workouts().size());
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new AuthException(AuthErrorCode.AUTHENTICATION_USER_NOT_FOUND));
+    public AppleWorkoutsImportResponse importAppleWorkouts(User user, AppleWorkoutsImportRequest request) {
+        log.info("Apple 운동 기록 업로드 시작: userId={}, count={}", user.getId(), request.workouts().size());
 
         List<AppleWorkoutImportResponse> importedActivities = new ArrayList<>();
 
@@ -792,13 +789,13 @@ public class ActivityService {
 
             } catch (Exception e) {
                 log.error("Apple 운동 기록 업로드 실패: userId={}, title={}", 
-                        userId, workoutRequest.title(), e);
+                        user.getId(), workoutRequest.title(), e);
                 // 개별 실패는 로그만 남기고 계속 진행
             }
         }
 
         log.info("Apple 운동 기록 업로드 완료: userId={}, successCount={}", 
-                userId, importedActivities.size());
+                user.getId(), importedActivities.size());
 
         return AppleWorkoutsImportResponse.of(importedActivities);
     }

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/CreateRouteResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/CreateRouteResponse.java
@@ -10,8 +10,8 @@ public record CreateRouteResponse(
         @Schema(description = "경로 제목", example = "한강 라이딩")
         String title,
 
-        @Schema(description = "예상 소요 시간 (분)", example = "60")
-        long totalDuration,
+        @Schema(description = "예상 소요 시간 (초)", example = "3600")
+        long totalDurationSeconds,
 
         @Schema(description = "총 거리 (km)", example = "13.2")
         double totalDistance,
@@ -24,7 +24,7 @@ public record CreateRouteResponse(
         return new CreateRouteResponse(
                 route.getRouteId().toString(),
                 route.getTitle(),
-                route.getDuration().toMinutes(),
+                route.getDuration().toSeconds(),
                 route.getDistanceInKm(),
                 route.getElevationGain()
         );

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RecommendationDetailResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RecommendationDetailResponse.java
@@ -41,8 +41,8 @@ public record RecommendationDetailResponse(
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDateTime createdAt,
 
-    @Schema(description = "예상 소요시간(분)", example = "71")
-    Long durationMinutes,
+    @Schema(description = "예상 소요시간(초)", example = "4260")
+    Long durationSeconds,
 
     @Schema(description = "이동 거리 (km)", example = "13.2")
     Double distance,
@@ -94,7 +94,7 @@ public record RecommendationDetailResponse(
                 route.getRegion().getDisplayName(),
                 GeometryUtil.lineStringToPolyline(route.getRouteLine()),
                 route.getCreatedAt(),
-                route.getDuration().toMinutes(),
+                route.getDuration().toSeconds(),
                 route.getDistance(),
                 route.getElevationGain(),
                 route.getUser().getUuid().toString(),

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RecommendationListResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RecommendationListResponse.java
@@ -46,8 +46,8 @@ public record RecommendationListResponse(
         @Schema(description = "총 거리 (km)", example = "13.2")
         Double distanceKm,
         
-        @Schema(description = "총 소요 시간 (분)", example = "60")
-        Long durationMinutes,
+        @Schema(description = "총 소요 시간 (초)", example = "3600")
+        Long durationSeconds,
         
         @Schema(description = "총 상승 고도 (m)", example = "120.4")
         Double elevationGain,
@@ -71,7 +71,7 @@ public record RecommendationListResponse(
                 route.getTitle(),
                 route.getDescription(),
                 route.getDistanceInKm(),
-                route.getDuration().toMinutes(),
+                route.getDuration().toSeconds(),
                 route.getRoundedElevationGain(),
                 route.getRegion().getDisplayName(),
                 route.getDifficulty().getDisplayName(),

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteDetailResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteDetailResponse.java
@@ -27,8 +27,8 @@ public record RouteDetailResponse(
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDateTime createdAt,
 
-    @Schema(description = "예상 소요시간(분)", example = "71")
-    Long durationMinutes,
+    @Schema(description = "예상 소요시간(초)", example = "4260")
+    Long durationSeconds,
 
     @Schema(description = "이동 거리 (km)", example = "13.2")
     Double distance,
@@ -76,7 +76,7 @@ public record RouteDetailResponse(
             route.getTitle(),
             GeometryUtil.lineStringToPolyline(route.getRouteLine()),
             route.getCreatedAt(),
-            route.getDuration().toMinutes(),
+            route.getDuration().toSeconds(),
             route.getDistance(),
             route.getElevationGain(),
             route.getUser().getUuid().toString(),

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteSegmentResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteSegmentResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 public record RouteSegmentResponse(
         List<Double> bbox,
         List<List<Double>> geometry,
-        int totalDuration,
+        int totalDurationSeconds,
         double totalDistance,
         double averageGradient
 ) {

--- a/src/main/java/com/ridingmate/api_server/domain/user/entity/AppleUser.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/entity/AppleUser.java
@@ -1,0 +1,69 @@
+package com.ridingmate.api_server.domain.user.entity;
+
+import com.ridingmate.api_server.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Apple HealthKit 연동 사용자 정보
+ */
+@Entity
+@Table(name = "apple_users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AppleUser extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive = true;
+
+    @Column(name = "last_sync_date")
+    private LocalDateTime lastSyncDate;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public AppleUser(User user, boolean isActive, 
+                     LocalDateTime lastSyncDate) {
+        this.user = user;
+        this.isActive = isActive;
+        this.lastSyncDate = lastSyncDate;
+    }
+
+    /**
+     * Apple 연동 활성화
+     */
+    public void activate() {
+        this.isActive = true;
+        this.lastSyncDate = LocalDateTime.now();
+    }
+
+    /**
+     * Apple 연동 비활성화
+     */
+    public void deactivate() {
+        this.isActive = false;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 마지막 동기화 시간 업데이트
+     */
+    public void updateLastSyncDate() {
+        this.lastSyncDate = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/exception/AppleErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/exception/AppleErrorCode.java
@@ -1,0 +1,24 @@
+package com.ridingmate.api_server.domain.user.exception;
+
+import com.ridingmate.api_server.global.exception.BaseCode;
+import com.ridingmate.api_server.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Apple 연동 관련 에러 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum AppleErrorCode implements ErrorCode {
+
+    APPLE_ALREADY_CONNECTED(HttpStatus.BAD_REQUEST, "APPLE_ALREADY_CONNECTED","이미 Apple HealthKit이 연동되어 있습니다. 기존 연동을 해제한 후 다시 시도해주세요."),
+    APPLE_NOT_CONNECTED(HttpStatus.BAD_REQUEST, "APPLE_NOT_CONNECTED","연동된 Apple HealthKit이 없습니다."),
+    APPLE_CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"APPLE_CONNECTED_FAILED" ,"Apple HealthKit 연동에 실패했습니다."),
+    APPLE_DISCONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE_DISCONNECTION_FAILED","Apple HealthKit 연동 해제에 실패했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/exception/AppleErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/exception/AppleErrorCode.java
@@ -14,7 +14,7 @@ import org.springframework.http.HttpStatus;
 public enum AppleErrorCode implements ErrorCode {
 
     APPLE_ALREADY_CONNECTED(HttpStatus.BAD_REQUEST, "APPLE_ALREADY_CONNECTED","이미 Apple HealthKit이 연동되어 있습니다. 기존 연동을 해제한 후 다시 시도해주세요."),
-    APPLE_NOT_CONNECTED(HttpStatus.BAD_REQUEST, "APPLE_NOT_CONNECTED","연동된 Apple HealthKit이 없습니다."),
+    APPLE_NOT_CONNECTED(HttpStatus.BAD_REQUEST, "APPLE_NOT_CONNECTED","연동된 Apple HealthKi 정보가 없습니다."),
     APPLE_CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"APPLE_CONNECTED_FAILED" ,"Apple HealthKit 연동에 실패했습니다."),
     APPLE_DISCONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE_DISCONNECTION_FAILED","Apple HealthKit 연동 해제에 실패했습니다.");
 

--- a/src/main/java/com/ridingmate/api_server/domain/user/exception/AppleException.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/exception/AppleException.java
@@ -1,0 +1,13 @@
+package com.ridingmate.api_server.domain.user.exception;
+
+import com.ridingmate.api_server.global.exception.BusinessException;
+
+/**
+ * Apple 연동 관련 예외
+ */
+public class AppleException extends BusinessException {
+
+    public AppleException(AppleErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/repository/AppleUserRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/repository/AppleUserRepository.java
@@ -1,0 +1,60 @@
+package com.ridingmate.api_server.domain.user.repository;
+
+import com.ridingmate.api_server.domain.user.entity.AppleUser;
+import com.ridingmate.api_server.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Apple 연동 사용자 Repository
+ */
+@Repository
+public interface AppleUserRepository extends JpaRepository<AppleUser, Long> {
+
+    /**
+     * 사용자별 Apple 연동 정보 조회 (활성화된 것만)
+     */
+    @Query("SELECT au FROM AppleUser au WHERE au.user = :user AND au.isActive = true")
+    List<AppleUser> findAllByUserAndIsActiveTrue(@Param("user") User user);
+
+    /**
+     * 사용자별 모든 Apple 연동 정보 조회
+     */
+    List<AppleUser> findAllByUser(User user);
+
+    /**
+     * 사용자의 활성화된 Apple 연동 정보 조회 (한 사용자당 하나만)
+     */
+    @Query("SELECT au FROM AppleUser au WHERE au.user = :user AND au.isActive = true")
+    Optional<AppleUser> findByUserAndIsActiveTrue(@Param("user") User user);
+
+    /**
+     * 사용자별 활성화된 Apple 연동 개수 조회
+     */
+    @Query("SELECT COUNT(au) FROM AppleUser au WHERE au.user = :user AND au.isActive = true")
+    long countByUserAndIsActiveTrue(@Param("user") User user);
+
+    /**
+     * 특정 기간 내에 마지막 동기화된 Apple 연동 정보 조회
+     */
+    @Query("SELECT au FROM AppleUser au WHERE au.user = :user AND au.isActive = true AND au.lastSyncDate >= :startDate")
+    List<AppleUser> findActiveByUserAndLastSyncDateAfter(@Param("user") User user, @Param("startDate") LocalDateTime startDate);
+
+    /**
+     * 사용자별 가장 최근 Apple 연동 정보 조회
+     */
+    @Query("SELECT au FROM AppleUser au WHERE au.user = :user ORDER BY au.createdAt DESC")
+    Optional<AppleUser> findMostRecentByUser(@Param("user") User user);
+
+    /**
+     * 사용자별 Apple 연동 여부 확인
+     */
+    @Query("SELECT CASE WHEN COUNT(au) > 0 THEN true ELSE false END FROM AppleUser au WHERE au.user = :user AND au.isActive = true")
+    boolean existsByUserAndIsActiveTrue(@Param("user") User user);
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/service/AppleUserService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/service/AppleUserService.java
@@ -1,0 +1,172 @@
+package com.ridingmate.api_server.domain.user.service;
+
+import com.ridingmate.api_server.domain.user.entity.AppleUser;
+import com.ridingmate.api_server.domain.user.entity.User;
+import com.ridingmate.api_server.domain.user.exception.AppleErrorCode;
+import com.ridingmate.api_server.domain.user.exception.AppleException;
+import com.ridingmate.api_server.domain.user.repository.AppleUserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Apple 연동 사용자 Service
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleUserService {
+
+    private final AppleUserRepository appleUserRepository;
+
+    /**
+     * Apple 연동 조회 또는 생성 (getOrCreate 패턴)
+     */
+    @Transactional
+    public AppleUser getOrCreateAppleUser(User user) {
+        log.info("Apple 연동 조회 또는 생성: userId={}", user.getId());
+
+        // 기존 활성화된 연동이 있으면 반환
+        Optional<AppleUser> existingActiveAppleUser = appleUserRepository.findByUserAndIsActiveTrue(user);
+        if (existingActiveAppleUser.isPresent()) {
+            log.info("기존 Apple 연동 반환: userId={}, appleUserEntityId={}", 
+                    user.getId(), existingActiveAppleUser.get().getId());
+            return existingActiveAppleUser.get();
+        }
+
+        // 새로운 Apple 연동 생성
+        AppleUser appleUser = AppleUser.builder()
+                .user(user)
+                .isActive(true)
+                .build();
+
+        log.info("새 Apple 연동 생성 완료: userId={}, appleUserEntityId={}",
+                user.getId(), appleUser.getId());
+
+        return appleUserRepository.save(appleUser);
+    }
+
+    /**
+     * Apple 연동 강제 생성 (중복 시 오류)
+     */
+    @Transactional
+    public AppleUser createAppleUser(User user) {
+        log.info("Apple 연동 강제 생성: userId={}", user.getId());
+
+        // 기존 활성화된 연동이 있으면 오류
+        Optional<AppleUser> existingActiveAppleUser = appleUserRepository.findByUserAndIsActiveTrue(user);
+        if (existingActiveAppleUser.isPresent()) {
+            log.warn("이미 Apple HealthKit이 연동되어 있음: userId={}", user.getId());
+            throw new AppleException(AppleErrorCode.APPLE_ALREADY_CONNECTED);
+        }
+
+        // 새로운 Apple 연동 생성
+        AppleUser appleUser = AppleUser.builder()
+                .user(user)
+                .isActive(true)
+                .build();
+
+        AppleUser savedAppleUser = appleUserRepository.save(appleUser);
+        log.info("Apple 연동 강제 생성 완료: userId={}, appleUserEntityId={}", 
+                user.getId(), savedAppleUser.getId());
+
+        return savedAppleUser;
+    }
+
+    /**
+     * 사용자의 활성화된 Apple 연동 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<AppleUser> getActiveAppleUsers(User user) {
+        log.info("활성화된 Apple 연동 목록 조회: userId={}", user.getId());
+        return appleUserRepository.findAllByUserAndIsActiveTrue(user);
+    }
+
+    /**
+     * 사용자의 모든 Apple 연동 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<AppleUser> getAllAppleUsers(User user) {
+        log.info("모든 Apple 연동 목록 조회: userId={}", user.getId());
+        return appleUserRepository.findAllByUser(user);
+    }
+
+    /**
+     * 사용자의 활성화된 Apple 연동 정보 조회
+     */
+    @Transactional(readOnly = true)
+    public Optional<AppleUser> getActiveAppleUser(User user) {
+        log.info("사용자의 활성화된 Apple 연동 정보 조회: userId={}", user.getId());
+        return appleUserRepository.findByUserAndIsActiveTrue(user);
+    }
+
+    /**
+     * Apple 연동 해제
+     */
+    @Transactional
+    public void disconnectAppleUser(User user) {
+        log.info("Apple 연동 해제: userId={}", user.getId());
+
+        AppleUser appleUser = appleUserRepository.findByUserAndIsActiveTrue(user)
+                .orElseThrow(() -> new AppleException(AppleErrorCode.APPLE_NOT_CONNECTED));
+
+        appleUser.deactivate();
+        appleUserRepository.save(appleUser);
+
+        log.info("Apple 연동 해제 완료: userId={}", user.getId());
+    }
+
+    /**
+     * 마지막 동기화 시간 업데이트
+     */
+    @Transactional
+    public void updateLastSyncDate(AppleUser appleUser) {
+        log.info("Apple 연동 마지막 동기화 시간 업데이트: appleUserId={}", appleUser.getId());
+
+        appleUser.updateLastSyncDate();
+        appleUserRepository.save(appleUser);
+
+        log.info("Apple 연동 마지막 동기화 시간 업데이트 완료: appleUserId={}", appleUser.getId());
+    }
+
+    /**
+     * 사용자의 Apple 연동 여부 확인
+     */
+    @Transactional(readOnly = true)
+    public boolean hasActiveAppleUser(User user) {
+        log.info("Apple 연동 여부 확인: userId={}", user.getId());
+        return appleUserRepository.existsByUserAndIsActiveTrue(user);
+    }
+
+    /**
+     * 사용자의 Apple 연동 개수 조회
+     */
+    @Transactional(readOnly = true)
+    public long getActiveAppleUserCount(User user) {
+        log.info("활성화된 Apple 연동 개수 조회: userId={}", user.getId());
+        return appleUserRepository.countByUserAndIsActiveTrue(user);
+    }
+
+    /**
+     * 사용자의 가장 최근 Apple 연동 정보 조회
+     */
+    @Transactional(readOnly = true)
+    public Optional<AppleUser> getMostRecentAppleUser(User user) {
+        log.info("가장 최근 Apple 연동 정보 조회: userId={}", user.getId());
+        return appleUserRepository.findMostRecentByUser(user);
+    }
+
+    /**
+     * 특정 기간 내에 동기화된 Apple 연동 정보 조회
+     */
+    @Transactional(readOnly = true)
+    public List<AppleUser> getActiveAppleUsersAfterDate(User user, LocalDateTime startDate) {
+        log.info("특정 기간 내 Apple 연동 정보 조회: userId={}, startDate={}", user.getId(), startDate);
+        return appleUserRepository.findActiveByUserAndLastSyncDateAfter(user, startDate);
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/user/service/AppleUserService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/user/service/AppleUserService.java
@@ -106,6 +106,16 @@ public class AppleUserService {
     }
 
     /**
+     * 사용자의 활성화된 Apple 연동 정보 조회 (없으면 Exception 발생)
+     */
+    @Transactional(readOnly = true)
+    public AppleUser getAppleUser(User user) {
+        log.info("사용자의 Apple 연동 정보 조회: userId={}", user.getId());
+        return appleUserRepository.findByUserAndIsActiveTrue(user)
+                .orElseThrow(() -> new AppleException(AppleErrorCode.APPLE_NOT_CONNECTED));
+    }
+
+    /**
      * Apple 연동 해제
      */
     @Transactional


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용

1. 연동 여부를 추가 및 확인하는 api를 추가하였습니다
[POST /api/integration/apple/connect] - 애플 연동 여부 추가
[GET /api/integration/apple/status] - 애플 연동 여부 확인
[DELETE /api/integration/provider/{providerName}] - 기존 api에 APPLE-HEALTH-KIT 추가하여 애플 헬스킷 연동 제거처리하도록 추가

2. API(운동 기록 연동) 사용량 조회 시 apple관련 정보도 추가(연동했다면)

3. apple health kit 운동 기록 업로드 시 심박수, 상승고도 정보 계산하도록 추가

4. 응답에서 duration을 모두 second 단위로 통일 및 네이밍규칙 통일 
(ex.totalDurationSeconds, durationSeconds) -> duration뒤에 Seconds를 모두 붙임

duration 관련 수정된 api 목록 및 수정 내용입니다 기존에 분단위가 많았어서 조금 수정할 내용이 많을 것 같습니다

1. 경로 생성 API (POST /api/routes)
변경사항: totalDuration (분) → totalDurationSeconds (초)

2. 추천 경로 목록 API (GET /api/routes/recommendations)
변경사항: durationMinutes (분) → durationSeconds (초)

3. 추천 경로 상세 API (GET /api/routes/recommendations/{routeId})
변경사항: durationMinutes (분) → durationSeconds (초)

4. 경로 세그먼트 API (GET /api/routes/{routeId}/segments)
변경사항: totalDuration → totalDurationSeconds (명칭 변경, 단위는 이미 초)

5. 경로 상세 API (GET /api/routes/{routeId})
변경사항: durationMinutes (분) → durationSeconds (초)

6. 활동 상세 API (GET /api/activities/{activityId})
변경사항:
activeDurationMinutes (분) → activeDurationSeconds (초)
totalDurationMinutes (분) → totalDurationSeconds (초)

7. 활동 목록 API (GET /api/activities)
변경사항: duration -> durationSeconds (명칭 변경, 단위는 이미 초)

8. 활동 통계 API (GET /api/activities/stats)
변경사항: 
summary.totalDuration -> summary.totalDurationSeconds (명칭 변경, 단위는 이미 초)
details.duration -> details.durationSeconds (명칭 변경, 단위는 이미 초)



## PR 포인트

## 고민과 학습내용

## 스크린샷
