### PR TITLE
[Feat] 주행기록에 칼로리 정보 추가

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ActivityDetailResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/ActivityDetailResponse.java
@@ -62,6 +62,9 @@ public record ActivityDetailResponse(
         @Schema(description = "최고 파워 (W)", example = "--")
         Integer maxPower,
 
+        @Schema(description = "소모 칼로리 (kcal)", example = "450.0")
+        Double calories,
+
         @Schema(description = "사용자 정보")
         UserInfo user,
 
@@ -194,6 +197,7 @@ public record ActivityDetailResponse(
                 activity.getMaxHeartRate(),
                 activity.getAveragePower(),
                 activity.getMaxPower(),
+                activity.getCalories(),
                 userInfo,
                 thumbnailImageUrl,
                 activityImages,

--- a/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/AppleWorkoutImportResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/dto/response/AppleWorkoutImportResponse.java
@@ -61,7 +61,7 @@ public record AppleWorkoutImportResponse(
                 activity.getEndedAt(),
                 activity.getDistance(),
                 activity.getDuration() != null ? activity.getDuration().getSeconds() : null,
-                null, // calories는 Activity 엔티티에 없음
+                activity.getCalories(), // Activity 엔티티의 칼로리 정보
                 activity.getAverageHeartRate(),
                 activity.getMaxHeartRate(),
                 activity.getCadence(),

--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/Activity.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/Activity.java
@@ -93,6 +93,12 @@ public class Activity extends BaseTimeEntity {
     private Integer maxPower;
 
     /**
+     * 소모 칼로리 (kcal)
+     */
+    @Column(name = "calories")
+    private Double calories;
+
+    /**
      * 삭제 여부 (소프트 삭제)
      */
     @Column(name = "is_delete", nullable = false)
@@ -104,7 +110,7 @@ public class Activity extends BaseTimeEntity {
                      LocalDateTime startedAt, LocalDateTime endedAt,
                      String thumbnailImagePath, Integer cadence,
                      Integer averageHeartRate, Integer maxHeartRate,
-                     Integer averagePower, Integer maxPower
+                     Integer averagePower, Integer maxPower, Double calories
     ){
         this.user = user;
         this.title = title;
@@ -119,6 +125,7 @@ public class Activity extends BaseTimeEntity {
         this.maxHeartRate = maxHeartRate;
         this.averagePower = averagePower;
         this.maxPower = maxPower;
+        this.calories = calories;
         this.activityId = UUID.randomUUID();
     }
 

--- a/src/main/java/com/ridingmate/api_server/domain/activity/service/ActivityService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/service/ActivityService.java
@@ -851,6 +851,7 @@ public class ActivityService {
                 .maxHeartRate(maxHeartRate)
                 .averagePower(null) // Apple HealthKit에서는 파워를 별도로 제공하지 않음
                 .maxPower(null) // Apple HealthKit에서는 파워를 별도로 제공하지 않음
+                .calories(request.calories()) // Apple HealthKit에서 제공하는 칼로리 정보
                 .build();
     }
 

--- a/src/main/java/com/ridingmate/api_server/domain/activity/service/ActivityService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/service/ActivityService.java
@@ -83,6 +83,10 @@ public class ActivityService {
         Integer maxPower = activityData.powerData() != null && activityData.powerData().maxPowerWatts() != null 
                 ? activityData.powerData().maxPowerWatts().intValue() : null;
 
+        // 칼로리 정보 추출
+        Double calories = activityData.caloriesData() != null && activityData.caloriesData().totalBurnedCalories() != null 
+                ? activityData.caloriesData().totalBurnedCalories() : null;
+
         Activity activity = Activity.builder()
                 .user(user)
                 .title(metadata.name() != null ? metadata.name() : "Terra 연동 활동")
@@ -96,6 +100,7 @@ public class ActivityService {
                 .maxHeartRate(maxHeartRate)
                 .averagePower(avgPower)
                 .maxPower(maxPower)
+                .calories(calories)
                 .build();
 
         // Activity 저장

--- a/src/main/java/com/ridingmate/api_server/infra/terra/dto/response/TerraPayload.java
+++ b/src/main/java/com/ridingmate/api_server/infra/terra/dto/response/TerraPayload.java
@@ -25,7 +25,8 @@ public record TerraPayload(
             @JsonProperty("movement_data") MovementData movementData,
             @JsonProperty("cadence_data") CadenceData cadenceData,
             @JsonProperty("heart_rate_data") HeartRateData heartRateData,
-            @JsonProperty("power_data") PowerData powerData
+            @JsonProperty("power_data") PowerData powerData,
+            @JsonProperty("calories_data") CaloriesData caloriesData
     ) {}
 
     public record Metadata(
@@ -124,6 +125,21 @@ public record TerraPayload(
     public record PowerSample(
             @JsonProperty("power_watts") Double powerWatts,
             OffsetDateTime timestamp,
+            @JsonProperty("timer_duration_seconds") Long timerDurationSeconds
+    ) {}
+
+    // 칼로리 데이터
+    public record CaloriesData(
+            @JsonProperty("total_burned_calories") Double totalBurnedCalories,
+            @JsonProperty("net_activity_calories") Double netActivityCalories,
+            @JsonProperty("BMR_calories") Double bmrCalories,
+            @JsonProperty("net_intake_calories") Double netIntakeCalories,
+            @JsonProperty("calorie_samples") List<CalorieSample> calorieSamples
+    ) {}
+
+    public record CalorieSample(
+            OffsetDateTime timestamp,
+            @JsonProperty("calories") Double calories,
             @JsonProperty("timer_duration_seconds") Long timerDurationSeconds
     ) {}
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용

1. 주행 기록(Activity)에 칼로리 정보를 추가하여 상세 조회 시 칼로리 정보(현재는 총 칼로리 소모량만)를 반환합니다.

2. Apple Health Kit로 업로드시 칼로리 정보를 Activity에 저장하도록 로직을 추가했습니다

3. 테라에서 받아오는 운동정보에서도 칼로리 정보를 저장하도록 했습니다
-> 해당 부분은 지금 스트라바 연결쪽에 문제가 있어서 테스트를 못해봤습니다 ㅠ 순토같은 다른곳에서 테스트 가능하도록 만들어보겠습니다

## PR 포인트

## 고민과 학습내용

## 스크린샷
