### PR TITLE
[Fix] 카카오 이메일 누락으로 인해 사용자 검증 로직을 provider + socialId로 검증하도록 변경

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/auth/security/AuthUser.java
+++ b/src/main/java/com/ridingmate/api_server/domain/auth/security/AuthUser.java
@@ -23,7 +23,7 @@ public record AuthUser(
         return new AuthUser(
                 user.getId(),
                 user.getUuid(),
-                user.getEmail()
+                user.getSocialProvider() + ":" + user.getSocialId()
         );
     }
 

--- a/src/main/java/com/ridingmate/api_server/domain/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/auth/security/CustomUserDetailsService.java
@@ -1,14 +1,17 @@
 package com.ridingmate.api_server.domain.auth.security;
 
+import com.ridingmate.api_server.domain.auth.enums.SocialProvider;
 import com.ridingmate.api_server.domain.user.entity.User;
 import com.ridingmate.api_server.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
@@ -18,9 +21,28 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(username)
-                .orElseThrow(() -> new UsernameNotFoundException("해당하는 이메일을 가진 유저를 찾을 수 없습니다: " + username));
-
-        return AuthUser.from(user);
+        log.debug("사용자 인증 시도: {}", username);
+        
+        // username 형식: "provider:socialId" (예: "KAKAO:1234567890")
+        String[] parts = username.split(":");
+        if (parts.length != 2) {
+            throw new UsernameNotFoundException("잘못된 사용자명 형식입니다: " + username);
+        }
+        
+        try {
+            SocialProvider provider = SocialProvider.valueOf(parts[0]);
+            String socialId = parts[1];
+            
+            User user = userRepository.findBySocialProviderAndSocialIdAndDeletedAtIsNull(provider, socialId)
+                    .orElseThrow(() -> new UsernameNotFoundException("해당하는 소셜 ID를 가진 유저를 찾을 수 없습니다: " + username));
+            
+            log.debug("사용자 인증 성공: userId={}, provider={}, socialId={}", 
+                    user.getId(), provider, socialId);
+            
+            return AuthUser.from(user);
+            
+        } catch (IllegalArgumentException e) {
+            throw new UsernameNotFoundException("지원하지 않는 소셜 프로바이더입니다: " + parts[0]);
+        }
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/auth/validator/KakaoIdTokenValidator.java
+++ b/src/main/java/com/ridingmate/api_server/domain/auth/validator/KakaoIdTokenValidator.java
@@ -34,9 +34,21 @@ public class KakaoIdTokenValidator {
             
             // 사용자 정보 추출
             String userId = String.valueOf(userInfoResponse.id());
+            
+            // 카카오 계정 정보 로깅
+            log.debug("Kakao API 응답 - ID: {}, kakaoAccount: {}", userId, userInfoResponse.kakaoAccount());
+            
             String email = userInfoResponse.kakaoAccount() != null
                 ? userInfoResponse.kakaoAccount().email()
                 : null;
+            
+            log.debug("추출된 이메일: {}", email);
+            
+            // 이메일이 없는 경우 대체 이메일 생성 (카카오 비즈니스 인증 없이는 이메일을 받기 어려움)
+            if (email == null || email.isEmpty()) {
+                email = "kakao_" + userId + "@kakao.local";
+                log.warn("카카오 사용자 이메일 정보 없음 - 대체 이메일 생성: {}", email);
+            }
             
             String nickname = userInfoResponse.properties() != null
                 ? userInfoResponse.properties().nickname()


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용

## PR 포인트

## 고민과 학습내용

## 스크린샷
